### PR TITLE
fix for BeamNG 0.37

### DIFF
--- a/BeamNG_LevelCleanUp/AutoUpdater.xml
+++ b/BeamNG_LevelCleanUp/AutoUpdater.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <item>
-  <version>1.2.1.0</version>
+  <version>1.2.2.0</version>
   <url>https://github.com/alexkleinwaechter/BeamNG_LevelCleanUp/releases/latest/download/BeamNG_LevelCleanUp.zip</url>
   <changelog>https://github.com/alexkleinwaechter/BeamNG_LevelCleanUp/releases/</changelog>
   <mandatory>false</mandatory>

--- a/BeamNG_LevelCleanUp/BeamNG_LevelCleanUp.csproj
+++ b/BeamNG_LevelCleanUp/BeamNG_LevelCleanUp.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
-    <FileVersion>1.2.1.0</FileVersion>
+    <AssemblyVersion>1.2.2.0</AssemblyVersion>
+    <FileVersion>1.2.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BeamNG_LevelCleanUp/Logic/CustomChangesChecker.cs
+++ b/BeamNG_LevelCleanUp/Logic/CustomChangesChecker.cs
@@ -21,17 +21,28 @@ namespace BeamNG_LevelCleanUp.Logic
 
         internal bool HasCustomChanges()
         {
-            // Pfad zum Benutzerordner
-            string userFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BeamNG.drive");
+            // Neuer Pfad zum Benutzerordner mit "current" Unterordner
+            string newUserFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BeamNG", "BeamNG.drive", "current");
+            
+            // Prüfen ob der neue Pfad existiert
+            if (Directory.Exists(newUserFolderPath))
+            {
+                // Neuer Pfad verwenden
+                _levelFolderPathChanges = Path.Combine(newUserFolderPath, "levels", _levelName);
+                return Directory.Exists(_levelFolderPathChanges);
+            }
 
-            // Überprüfen, ob der Benutzerordner existiert
-            if (!Directory.Exists(userFolderPath))
+            // Fallback: Alter Pfad für ältere Versionen
+            string oldUserFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "BeamNG.drive");
+
+            // Überprüfen, ob der alte Benutzerordner existiert
+            if (!Directory.Exists(oldUserFolderPath))
             {
                 return false;
             }
 
             // Alle Unterordner abrufen und die höchste Versionsnummer finden
-            var versionFolders = Directory.GetDirectories(userFolderPath)
+            var versionFolders = Directory.GetDirectories(oldUserFolderPath)
                 .Select(Path.GetFileName)
                 .Where(folderName => Version.TryParse(folderName, out _)) // Nur gültige Versionsordner
                 .OrderByDescending(folderName => Version.Parse(folderName)) // Absteigend sortieren
@@ -43,7 +54,7 @@ namespace BeamNG_LevelCleanUp.Logic
             }
 
             // Höchste Versionsnummer abrufen
-            string highestVersionFolder = Path.Combine(userFolderPath, versionFolders.First());
+            string highestVersionFolder = Path.Combine(oldUserFolderPath, versionFolders.First());
 
             // Überprüfen, ob der Ordner "/levels/[_levelName]" existiert
             _levelFolderPathChanges = Path.Combine(highestVersionFolder, "levels", _levelName);

--- a/etsmaterialgen/EtsMaterialConverter.cs
+++ b/etsmaterialgen/EtsMaterialConverter.cs
@@ -42,6 +42,11 @@ namespace etsmaterialgen
             {
                 fiMaterials.MoveTo($"{fiMaterials.FullName}.{DateTime.Now.Ticks}.bak");
             }
+            
+            if (!Directory.Exists(fiMaterials.DirectoryName))
+            {
+                Directory.CreateDirectory(fiMaterials.DirectoryName);
+            }
 
             File.WriteAllText(_materialsJson, newMatJson);
         }


### PR DESCRIPTION
This pull request updates the version of the application to 1.2.2.0 and introduces improvements to compatibility with newer and older BeamNG user folder structures. It also adds a fix to ensure directories exist before writing files in the material converter. The main changes are as follows:

**Version Update:**

* Updated the application version to `1.2.2.0` in both the `AutoUpdater.xml` and `BeamNG_LevelCleanUp.csproj` files. [[1]](diffhunk://#diff-a9b0de7751f480ba813d1cab36f890fb29d1ba8d78912d055523023d30358a6eL3-R3) [[2]](diffhunk://#diff-3b5ab573eebe5a5320cd4dadc3776c7c63c4064beb205a6ef9156f7465357070L9-R10)

**Compatibility Improvements:**

* Enhanced the `CustomChangesChecker` in `CustomChangesChecker.cs` to first check for the new BeamNG user folder structure (`BeamNG/BeamNG.drive/current`) and fall back to the old structure if not found, ensuring compatibility with both newer and older versions of BeamNG.
* Fixed path usage in the fallback logic to correctly use `oldUserFolderPath` when determining the highest version folder.

**File Handling Robustness:**

* In `EtsMaterialConverter.cs`, added logic to create the target directory if it does not exist before writing the `materials.json` file, preventing potential errors during file operations.