### PR TITLE
Generate terrain from classified LAS and LAZ point clouds

### DIFF
--- a/BeamNG_LevelCleanUp/BlazorUI/Components/HeightmapSourceHelpDialog.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/HeightmapSourceHelpDialog.razor
@@ -261,6 +261,39 @@
 
             <MudDivider Class="my-4" />
 
+            <MudText Typo="Typo.h6" Class="mb-2" Color="Color.Primary">
+                <MudIcon Icon="@Icons.Material.Filled.ScatterPlot" Size="Size.Small" Class="mr-1" />
+                Classified LAS/LAZ to Ground DTM
+            </MudText>
+
+            <MudText Typo="Typo.body2" Class="mb-2">
+                For the highest-detail source, download classified LAS/LAZ tiles and import them directly.
+                LevelCleanUp streams the files, keeps ASPRS class 2 bare-earth points, fills cells between
+                measured points, and writes a 16-bit DTM PNG plus the BeamNG terrain.
+            </MudText>
+
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mb-3">
+                USA: use the
+                <MudLink Href="https://apps.nationalmap.gov/lidar-explorer/" Target="_blank">
+                    USGS LidarExplorer
+                </MudLink>
+                to find and download source point-cloud tiles. Select all LAS/LAZ tiles intersecting the map square.
+            </MudAlert>
+
+            <MudList T="string" Dense="true" Class="mb-3">
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check" IconColor="Color.Success">
+                    Use a projected CRS in linear units; embedded EPSG metadata is detected when available.
+                </MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Check" IconColor="Color.Success">
+                    Start with 0.5 m for dense QL0/QL1 data or 1.0 m for typical QL2 data.
+                </MudListItem>
+                <MudListItem T="string" Icon="@Icons.Material.Filled.Warning" IconColor="Color.Warning">
+                    A finer cell size only preserves more detail when the ground-point density supports it.
+                </MudListItem>
+            </MudList>
+
+            <MudDivider Class="my-4" />
+
             @* Section 4: Tips *@
             <MudText Typo="Typo.h6" Class="mb-2" Color="Color.Primary">
                 <MudIcon Icon="@Icons.Material.Filled.Lightbulb" Size="Size.Small" Class="mr-1" />

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetExporter.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetExporter.razor
@@ -65,6 +65,8 @@
     [Parameter] public string? XyzPath { get; set; }
     [Parameter] public string[]? XyzFilePaths { get; set; }
     [Parameter] public int XyzEpsgCode { get; set; }
+    [Parameter] public string[]? LidarFilePaths { get; set; }
+    [Parameter] public int LidarEpsgCode { get; set; }
     [Parameter] public string? CachedCombinedGeoTiffPath { get; set; }
     [Parameter] public bool UpdateTerrainBlock { get; set; } = true;
     [Parameter] public bool EnableCrossMaterialHarmonization { get; set; }
@@ -550,6 +552,18 @@
                 foreach (var p in XyzFilePaths)
                     pathsArray.Add(p);
                 source["originalXyzFilePaths"] = pathsArray;
+            }
+        }
+
+        if (HeightmapSourceType == HeightmapSourceType.LidarPointCloud)
+        {
+            source["lidarEpsgCode"] = LidarEpsgCode;
+            if (LidarFilePaths is { Length: > 0 })
+            {
+                var pathsArray = new JsonArray();
+                foreach (var path in LidarFilePaths)
+                    pathsArray.Add(path);
+                source["originalLidarFilePaths"] = pathsArray;
             }
         }
 

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetImporter.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetImporter.razor
@@ -668,6 +668,25 @@ public List<TerrainMaterialItemExtended> Materials { get; set; } = new();
                                 "Please re-import elevation data.");
                         }
                     }
+                    else if (result.HeightmapSourceType == HeightmapSourceType.LidarPointCloud)
+                    {
+                        var lidarEpsgCode = heightmapSource["lidarEpsgCode"]?.GetValue<int>();
+                        var lidarPathsNode = heightmapSource["originalLidarFilePaths"]?.AsArray();
+                        var lidarPaths = lidarPathsNode?
+                            .Select(node => node?.GetValue<string>())
+                            .Where(path => !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+                            .Cast<string>()
+                            .ToArray() ?? [];
+
+                        result.LidarFilePaths = lidarPaths;
+                        result.LidarEpsgCode = lidarEpsgCode;
+
+                        if (lidarPaths.Length == 0)
+                        {
+                            PubSubChannel.SendMessage(PubSubMessageType.Warning,
+                                "LAS/LAZ files from this preset were not found. Re-import the point-cloud tiles.");
+                        }
+                    }
                 }
             }
 

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetResult.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetResult.cs
@@ -12,7 +12,8 @@ public enum HeightmapSourceType
     Png,
     GeoTiffFile,
     GeoTiffDirectory,
-    XyzFile
+    XyzFile,
+    LidarPointCloud
 }
 
 /// <summary>
@@ -82,6 +83,10 @@ public class TerrainPresetResult
     ///     EPSG code for XYZ coordinate system (when HeightmapSourceType is XyzFile).
     /// </summary>
     public int? XyzEpsgCode { get; set; }
+
+    public string[]? LidarFilePaths { get; set; }
+
+    public int? LidarEpsgCode { get; set; }
 
     // ========== NEW: Terrain Generation Options ==========
 

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/UsgsLidarDialogResult.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/UsgsLidarDialogResult.cs
@@ -1,0 +1,8 @@
+using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
+
+namespace BeamNG_LevelCleanUp.BlazorUI.Components;
+
+public sealed record UsgsLidarDialogResult(
+    GeoBoundingBox Bounds,
+    IReadOnlyList<UsgsLidarProduct> Products);

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/UsgsLidarDownloadDialog.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/UsgsLidarDownloadDialog.razor
@@ -1,0 +1,245 @@
+@using BeamNgTerrainPoc.Terrain.GeoTiff
+@using BeamNgTerrainPoc.Terrain.Lidar
+@implements IDisposable
+
+<MudDialog>
+    <DialogContent>
+        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mb-4">
+            <MudText Typo="Typo.subtitle2">USGS 3DEP classified point clouds (free)</MudText>
+            <MudText Typo="Typo.body2">
+                Finds LAS/LAZ tiles intersecting the map area. LevelCleanUp filters ground-class points and
+                generates a high-detail DTM. Downloads can be large; completed files and partial progress are cached.
+            </MudText>
+        </MudAlert>
+
+        @if (_requiresCenter)
+        {
+            <MudAlert Severity="Severity.Warning" Dense="true" Class="mb-3">
+                This level has no saved geographic bounds. Enter the terrain center; the area is calculated
+                from terrain size × meters per pixel.
+            </MudAlert>
+            <MudGrid Spacing="2">
+                <MudItem xs="12" sm="6">
+                    <MudNumericField T="double?" @bind-Value="_centerLatitude"
+                                     Label="Center Latitude" Variant="Variant.Outlined"
+                                     Min="-85.0" Max="85.0" Step="0.0001" Immediate="true" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField T="double?" @bind-Value="_centerLongitude"
+                                     Label="Center Longitude" Variant="Variant.Outlined"
+                                     Min="-180.0" Max="180.0" Step="0.0001" Immediate="true" />
+                </MudItem>
+            </MudGrid>
+        }
+
+        @if (RequestBounds is { } bounds)
+        {
+            <MudPaper Outlined="true" Class="pa-3 mt-3">
+                <MudText Typo="Typo.subtitle2">Search area</MudText>
+                <MudText Typo="Typo.body2">
+                    @bounds.ApproximateWidthMeters.ToString("N0") m × @bounds.ApproximateHeightMeters.ToString("N0") m
+                </MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary">
+                    SW @bounds.MinLatitude.ToString("F6"), @bounds.MinLongitude.ToString("F6") ·
+                    NE @bounds.MaxLatitude.ToString("F6"), @bounds.MaxLongitude.ToString("F6")
+                </MudText>
+            </MudPaper>
+        }
+
+        <MudButton Color="Color.Primary" Variant="Variant.Filled" Class="mt-3"
+                   StartIcon="@Icons.Material.Filled.Search" OnClick="Search"
+                   Disabled="@_isSearching">
+            Find USGS 3DEP LAZ Tiles
+        </MudButton>
+
+        @if (_isSearching)
+        {
+            <div class="d-flex align-center gap-2 mt-3">
+                <MudProgressCircular Indeterminate="true" Size="Size.Small" />
+                <MudText Typo="Typo.body2">@_statusMessage</MudText>
+            </div>
+        }
+
+        @if (_searchResult != null)
+        {
+            @if (_searchResult.Products.Count == 0)
+            {
+                <MudAlert Severity="Severity.Warning" Class="mt-3">
+                    No USGS 3DEP classified LAS/LAZ tiles were found for this area. Try a raster DEM source instead.
+                </MudAlert>
+            }
+            else
+            {
+                <MudAlert Severity="Severity.Success" Dense="true" Class="mt-3">
+                    Found @_searchResult.Products.Count.ToString("N0") intersecting tile(s),
+                    approximately @FormatBytes(_searchResult.TotalSizeInBytes). All are selected by default.
+                </MudAlert>
+                @if (_searchResult.WasTruncated)
+                {
+                    <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
+                        The search exceeded @UsgsLidarDownloadService.MaximumSearchProducts.ToString("N0") products.
+                        Reduce the requested area before downloading.
+                    </MudAlert>
+                }
+
+                <MudTable T="UsgsLidarProduct" Items="_searchResult.Products"
+                          MultiSelection="true" @bind-SelectedItems="_selectedProducts"
+                          Hover="true" Dense="true" RowsPerPage="10" Class="mt-3">
+                    <HeaderContent>
+                        <MudTh>USGS product</MudTh>
+                        <MudTh>Published</MudTh>
+                        <MudTh>Size</MudTh>
+                    </HeaderContent>
+                    <RowTemplate>
+                        <MudTd DataLabel="USGS product">@context.Title</MudTd>
+                        <MudTd DataLabel="Published">@FormatDate(context.PublicationDate)</MudTd>
+                        <MudTd DataLabel="Size">@FormatBytes(context.SizeInBytes)</MudTd>
+                    </RowTemplate>
+                    <PagerContent><MudTablePager /></PagerContent>
+                </MudTable>
+                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
+                    @_selectedProducts.Count.ToString("N0") tile(s) selected. LAZ keeps the original point-cloud detail;
+                    the final BeamNG resolution is set by the DTM meters-per-pixel control after import.
+                </MudText>
+            }
+        }
+
+        @if (!string.IsNullOrWhiteSpace(_errorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-3">@_errorMessage</MudAlert>
+        }
+
+        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-3">
+            <MudLink Href="https://apps.nationalmap.gov/lidar-explorer/" Target="_blank">Open USGS LidarExplorer</MudLink>
+        </MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Primary" Variant="Variant.Filled"
+                   StartIcon="@Icons.Material.Filled.CloudDownload"
+                   OnClick="Submit" Disabled="@(!_selectedProducts.Any() || _isSearching)">
+            Download Selected LAZ
+        </MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [Parameter] public GeoBoundingBox? InitialBounds { get; set; }
+    [Parameter] public int TerrainSize { get; set; }
+    [Parameter] public double MetersPerPixel { get; set; }
+
+    private readonly CancellationTokenSource _cancellation = new();
+    private readonly UsgsLidarDownloadService _service = new();
+    private double? _centerLatitude;
+    private double? _centerLongitude;
+    private bool _requiresCenter;
+    private bool _isSearching;
+    private string _statusMessage = "Searching...";
+    private string? _errorMessage;
+    private UsgsLidarSearchResult? _searchResult;
+    private HashSet<UsgsLidarProduct> _selectedProducts = new();
+
+    private GeoBoundingBox? RequestBounds
+    {
+        get
+        {
+            if (!_requiresCenter)
+                return InitialBounds;
+            if (!_centerLatitude.HasValue || !_centerLongitude.HasValue)
+                return null;
+            try
+            {
+                return UsgsLidarDownloadService.BuildSquareBounds(
+                    _centerLatitude.Value,
+                    _centerLongitude.Value,
+                    TerrainSize * MetersPerPixel);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+
+    protected override void OnParametersSet()
+    {
+        _requiresCenter = InitialBounds is not { IsValidWgs84: true };
+        if (!_requiresCenter && InitialBounds != null)
+        {
+            _centerLatitude = InitialBounds.Center.Latitude;
+            _centerLongitude = InitialBounds.Center.Longitude;
+        }
+    }
+
+    private async Task Search()
+    {
+        _errorMessage = null;
+        _searchResult = null;
+        _selectedProducts.Clear();
+        if (RequestBounds is not { } bounds)
+        {
+            _errorMessage = "Enter a valid center latitude and longitude.";
+            return;
+        }
+
+        _isSearching = true;
+        try
+        {
+            var progress = new Progress<string>(message =>
+            {
+                _statusMessage = message;
+                _ = InvokeAsync(StateHasChanged);
+            });
+            _searchResult = await _service.SearchAsync(bounds, progress, _cancellation.Token);
+            _selectedProducts = _searchResult.Products.ToHashSet();
+        }
+        catch (OperationCanceledException)
+        {
+            // Dialog is closing.
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"USGS search failed: {ex.Message}";
+        }
+        finally
+        {
+            _isSearching = false;
+        }
+    }
+
+    private void Submit()
+    {
+        if (RequestBounds is not { } bounds || !_selectedProducts.Any())
+            return;
+        MudDialog.Close(DialogResult.Ok(new UsgsLidarDialogResult(
+            bounds,
+            _selectedProducts.OrderBy(product => product.Title, StringComparer.OrdinalIgnoreCase).ToList())));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes <= 0) return "unknown size";
+        string[] units = ["B", "KB", "MB", "GB", "TB"];
+        var value = (double)bytes;
+        var unit = 0;
+        while (value >= 1024 && unit < units.Length - 1)
+        {
+            value /= 1024;
+            unit++;
+        }
+        return $"{value:0.##} {units[unit]}";
+    }
+
+    private static string FormatDate(string? value) =>
+        DateTimeOffset.TryParse(value, out var date) ? date.ToString("yyyy-MM-dd") : "—";
+
+    public void Dispose()
+    {
+        _cancellation.Cancel();
+        _cancellation.Dispose();
+        _service.Dispose();
+    }
+}

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
@@ -104,6 +104,8 @@
                                        XyzPath="@_state.XyzPath"
                                        XyzFilePaths="@_state.XyzFilePaths"
                                        XyzEpsgCode="@_xyzEpsgCode"
+                                       LidarFilePaths="@_state.LidarFilePaths"
+                                       LidarEpsgCode="@_state.LidarEpsgCode"
                                        CachedCombinedGeoTiffPath="@_cachedCombinedGeoTiffPath"
                                        UpdateTerrainBlock="@_updateTerrainBlock"
                                        EnableCrossMaterialHarmonization="@_enableCrossMaterialHarmonization"
@@ -179,7 +181,7 @@
                                         <strong>Select Folder:</strong> Import all elevation tiles from a directory.
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
-                                        Supported formats: GeoTIFF (.tif, .tiff), XYZ ASCII (.xyz, .txt), PNG heightmap (.png), ZIP archive (.zip)
+                                        Supported formats: GeoTIFF, XYZ ASCII, classified LAS/LAZ point clouds, PNG heightmap, ZIP archive
                                     </MudText>
                                 </MudPaper>
                             }
@@ -259,6 +261,38 @@
                                             }
                                         </div>
                                     }
+                                    @if (_elevationImportResult.SourceType == ElevationSourceType.LidarPointCloud)
+                                    {
+                                        <MudDivider Class="my-3" />
+                                        <MudAlert Severity="Severity.Info" Dense="true" Class="mb-3">
+                                            Only ASPRS <strong>classification 2 (bare-earth ground)</strong> is used.
+                                            Empty cells are interpolated; choosing cells finer than the measured point spacing does not create new detail.
+                                            The original LAS/LAZ files are read locally and are never modified.
+                                        </MudAlert>
+                                        <MudSelect T="float"
+                                                   Value="@_metersPerPixel"
+                                                   ValueChanged="OnLidarResolutionChanged"
+                                                   Label="Ground DTM Cell Size"
+                                                   Variant="Variant.Outlined"
+                                                   HelperText="Also becomes BeamNG terrain squareSize"
+                                                   Style="max-width: 280px;">
+                                            <MudSelectItem Value="0.25f">0.25 m (only for very dense QL0/QL1)</MudSelectItem>
+                                            <MudSelectItem Value="0.5f">0.5 m (high-detail)</MudSelectItem>
+                                            <MudSelectItem Value="1.0f">1.0 m (QL2 / larger coverage)</MudSelectItem>
+                                            <MudSelectItem Value="2.0f">2.0 m (very large coverage)</MudSelectItem>
+                                        </MudSelect>
+                                        <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
+                                            @GetLidarCoverageDescription()
+                                        </MudText>
+                                        <MudButton Href="https://apps.nationalmap.gov/lidar-explorer/"
+                                                   Target="_blank"
+                                                   Variant="Variant.Text"
+                                                   Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.OpenInNew"
+                                                   Class="mt-2">
+                                            Find USGS 3DEP LAS/LAZ Tiles
+                                        </MudButton>
+                                    }
                                 </MudPaper>
                             }
                         </MudItem>
@@ -285,7 +319,7 @@
                                     @if (_geoTiffMinElevation.HasValue && _geoTiffMaxElevation.HasValue)
                                     {
                                         <MudText Typo="Typo.body2">
-                                            <strong>Elevation:</strong> @_geoTiffMinElevation.Value.ToString("F1")m - @_geoTiffMaxElevation.Value.ToString("F1")m
+                                            <strong>@(_heightmapSourceType == HeightmapSourceType.LidarPointCloud ? "Header Elevation (all classes):" : "Elevation:")</strong> @_geoTiffMinElevation.Value.ToString("F1")m - @_geoTiffMaxElevation.Value.ToString("F1")m
                                             (range: @((_geoTiffMaxElevation.Value - _geoTiffMinElevation.Value).ToString("F1"))m)
                                         </MudText>
                                     }
@@ -391,7 +425,7 @@
                         {
                             <MudItem xs="12">
                                 <CropAnchorSelector @ref="_cropAnchorSelector"
-                                                    Title="GeoTIFF Selection Region"
+                                                    Title="@(_heightmapSourceType == HeightmapSourceType.LidarPointCloud ? "LAS/LAZ DTM Selection Region" : "GeoTIFF Selection Region")"
                                                     OriginalWidth="@_geoTiffOriginalWidth"
                                                     OriginalHeight="@_geoTiffOriginalHeight"
                                                     TargetSize="@_terrainSize"
@@ -403,7 +437,8 @@
                                                     SelectedAnchorChanged="OnCropAnchorChanged"
                                                     OriginalBoundingBox="@_geoBoundingBox"
                                                     CropResultChanged="OnCropResultChanged" />
-                                @if (_cropResult is { NeedsCropping: true })
+                                @if (_cropResult is { NeedsCropping: true } &&
+                                     _heightmapSourceType != HeightmapSourceType.LidarPointCloud)
                                 {
                                     <div class="d-flex align-center gap-2 mt-2">
                                         <MudButton Variant="Variant.Outlined"
@@ -453,13 +488,13 @@
                                              Label="Max Height (m)"
                                              Variant="Variant.Outlined"
                                              Min="0.0f" Max="10000.0f" Step="10.0f"
-                                             HelperText="@(_heightmapSourceType != HeightmapSourceType.Png ? "Set to 0 to auto-calculate from GeoTIFF" : "Maximum terrain elevation")" />
+                                             HelperText="@(_heightmapSourceType == HeightmapSourceType.LidarPointCloud ? "0 = calculate from ground-class points" : _heightmapSourceType != HeightmapSourceType.Png ? "Set to 0 to auto-calculate from elevation data" : "Maximum terrain elevation")" />
                         </MudItem>
 
                         <!-- Meters Per Pixel -->
                         <MudItem xs="12" sm="6" md="3">
                             <MudNumericField @bind-Value="_metersPerPixel"
-                                             Label="Meters Per Pixel"
+                                             Label="@(_heightmapSourceType == HeightmapSourceType.LidarPointCloud ? "DTM / Terrain Cell Size (m)" : "Meters Per Pixel")"
                                              Variant="Variant.Outlined"
                                              Min="0.1f" Max="100.0f" Step="0.1f"
                                              HelperText="@GetMetersPerPixelHelperText()" />
@@ -479,7 +514,7 @@
                                              Label="Base Height (m)"
                                              Variant="Variant.Outlined"
                                              Min="-10000.0f" Max="10000.0f" Step="1.0f"
-                                             HelperText="@(_heightmapSourceType != HeightmapSourceType.Png ? "Auto-calculated from GeoTIFF min elevation" : "Z position offset for terrain")" />
+                                             HelperText="@(_heightmapSourceType == HeightmapSourceType.LidarPointCloud ? "Calculated from class-2 ground points" : _heightmapSourceType != HeightmapSourceType.Png ? "Auto-calculated from elevation data minimum" : "Z position offset for terrain")" />
                         </MudItem>
 
                         @* Hydraulic Erosion *@

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
@@ -170,6 +170,13 @@
                                                    Disabled="@_isImportingElevation">
                                             Select Folder
                                         </MudButton>
+                                        <MudButton Variant="Variant.Outlined"
+                                                   Color="Color.Primary"
+                                                   StartIcon="@Icons.Material.Filled.Terrain"
+                                                   OnClick="DownloadUsgsLidar"
+                                                   Disabled="@_isImportingElevation">
+                                            USGS 3DEP Point Cloud (Free)
+                                        </MudButton>
                                         @if (_isImportingElevation)
                                         {
                                             <MudProgressCircular Size="Size.Small" Indeterminate="true" />
@@ -179,6 +186,7 @@
                                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-2">
                                         <strong>Select Files:</strong> Pick one or multiple files (hold Ctrl/Shift for multi-select).
                                         <strong>Select Folder:</strong> Import all elevation tiles from a directory.
+                                        <strong>USGS 3DEP:</strong> Find classified LAS/LAZ tiles and generate a bare-earth DTM.
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
                                         Supported formats: GeoTIFF, XYZ ASCII, classified LAS/LAZ point clouds, PNG heightmap, ZIP archive
@@ -284,13 +292,12 @@
                                         <MudText Typo="Typo.caption" Color="Color.Secondary" Class="mt-1">
                                             @GetLidarCoverageDescription()
                                         </MudText>
-                                        <MudButton Href="https://apps.nationalmap.gov/lidar-explorer/"
-                                                   Target="_blank"
+                                        <MudButton OnClick="DownloadUsgsLidar"
                                                    Variant="Variant.Text"
                                                    Color="Color.Primary"
-                                                   StartIcon="@Icons.Material.Filled.OpenInNew"
+                                                   StartIcon="@Icons.Material.Filled.Search"
                                                    Class="mt-2">
-                                            Find USGS 3DEP LAS/LAZ Tiles
+                                            Find or Add USGS 3DEP LAS/LAZ Tiles
                                         </MudButton>
                                     }
                                 </MudPaper>

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
@@ -995,6 +995,11 @@ public partial class GenerateTerrain : IDisposable
                 result = await _geoTiffService.ReadFromXyzFileAsync(_state.XyzFilePaths[0], _xyzEpsgCode);
             else if (!string.IsNullOrEmpty(_state.XyzPath) && File.Exists(_state.XyzPath))
                 result = await _geoTiffService.ReadFromXyzFileAsync(_state.XyzPath, _xyzEpsgCode);
+            else if (_state.LidarFilePaths is { Length: > 0 })
+                result = await _geoTiffService.ReadFromLidarFilesAsync(
+                    _state.LidarFilePaths,
+                    _state.LidarEpsgCode,
+                    _state.LidarMetadataCellSizeMeters);
 
             if (result == null) return;
 
@@ -1021,7 +1026,15 @@ public partial class GenerateTerrain : IDisposable
                     $"Keeping terrain size {_terrainSize} from terrain.json (GeoTIFF suggests {result.SuggestedTerrainSize.Value})");
 
             // Auto-populate maxHeight and terrainBaseHeight from GeoTIFF elevation data
-            if (_geoTiffMinElevation.HasValue && _geoTiffMaxElevation.HasValue)
+            if (_heightmapSourceType == HeightmapSourceType.LidarPointCloud)
+            {
+                // Header limits include vegetation/buildings. The exact class-2 range is calculated
+                // during DTM generation and then becomes MaxHeight/TerrainBaseHeight.
+                _maxHeight = 0;
+                if (_geoTiffMinElevation.HasValue)
+                    _terrainBaseHeight = (float)_geoTiffMinElevation.Value;
+            }
+            else if (_geoTiffMinElevation.HasValue && _geoTiffMaxElevation.HasValue)
             {
                 var elevationRange = _geoTiffMaxElevation.Value - _geoTiffMinElevation.Value;
                 _maxHeight = (float)elevationRange;
@@ -1038,7 +1051,12 @@ public partial class GenerateTerrain : IDisposable
             // Log scale information
             LogScaleInformation(result);
 
-            var formatLabel = _heightmapSourceType == HeightmapSourceType.XyzFile ? "XYZ" : "GeoTIFF";
+            var formatLabel = _heightmapSourceType switch
+            {
+                HeightmapSourceType.XyzFile => "XYZ",
+                HeightmapSourceType.LidarPointCloud => "LAS/LAZ",
+                _ => "GeoTIFF"
+            };
             finalMessage = $"{formatLabel} loaded: {result.OriginalWidth}×{result.OriginalHeight}px, " +
                            $"elevation {_geoTiffMinElevation:F0}m – {_geoTiffMaxElevation:F0}m";
             finalSeverity = Severity.Success;
@@ -1141,7 +1159,7 @@ public partial class GenerateTerrain : IDisposable
 
     /// <summary>
     ///     Opens a file dialog to select elevation data files, then imports them.
-    ///     Supports GeoTIFF (.tif, .tiff), XYZ ASCII (.xyz, .txt), PNG (.png), and ZIP (.zip).
+    ///     Supports GeoTIFF, XYZ ASCII, classified LAS/LAZ, PNG, and ZIP.
     /// </summary>
     private async Task ImportElevationFiles()
     {
@@ -1150,9 +1168,10 @@ public partial class GenerateTerrain : IDisposable
         {
             using var dialog = new OpenFileDialog();
             dialog.Filter =
-                "Elevation Files (*.tif;*.tiff;*.geotiff;*.xyz;*.txt;*.png;*.zip)|*.tif;*.tiff;*.geotiff;*.xyz;*.txt;*.png;*.zip|" +
+                "Elevation Files (*.tif;*.tiff;*.geotiff;*.xyz;*.txt;*.las;*.laz;*.png;*.zip)|*.tif;*.tiff;*.geotiff;*.xyz;*.txt;*.las;*.laz;*.png;*.zip|" +
                 "GeoTIFF (*.tif;*.tiff;*.geotiff)|*.tif;*.tiff;*.geotiff|" +
                 "XYZ ASCII (*.xyz;*.txt)|*.xyz;*.txt|" +
+                "Classified Point Cloud (*.las;*.laz)|*.las;*.laz|" +
                 "PNG Heightmap (*.png)|*.png|" +
                 "ZIP Archive (*.zip)|*.zip|" +
                 "All Files (*.*)|*.*";
@@ -1256,6 +1275,8 @@ public partial class GenerateTerrain : IDisposable
         _geoTiffPath = null;
         _geoTiffDirectory = null;
         _state.XyzPath = null;
+        _state.XyzFilePaths = null;
+        _state.LidarFilePaths = null;
 
         // Set source type and paths based on detected format
         switch (result.SourceType)
@@ -1290,6 +1311,15 @@ public partial class GenerateTerrain : IDisposable
                 _xyzEpsgCode = result.EpsgCode;
                 _state.XyzDetectedEpsg = result.DetectedEpsgCode;
                 break;
+
+            case ElevationSourceType.LidarPointCloud:
+                _heightmapSourceType = HeightmapSourceType.LidarPointCloud;
+                _state.LidarFilePaths = result.ResolvedLidarFilePaths;
+                _state.LidarEpsgCode = result.EpsgCode;
+                _xyzEpsgCode = result.EpsgCode;
+                _state.XyzDetectedEpsg = result.DetectedEpsgCode;
+                _metersPerPixel = _state.LidarMetadataCellSizeMeters;
+                break;
         }
 
         // Apply metadata if available
@@ -1310,6 +1340,9 @@ public partial class GenerateTerrain : IDisposable
             ElevationSourceType.GeoTiffMultiple => $"GeoTIFF tiles loaded: {result.FileCount} files",
             ElevationSourceType.XyzFile => $"XYZ file loaded: {result.FileNames[0]} (EPSG:{result.EpsgCode})",
             ElevationSourceType.XyzMultiple => $"XYZ tiles loaded: {result.FileCount} files (EPSG:{result.EpsgCode})",
+            ElevationSourceType.LidarPointCloud => result.EpsgCode > 0
+                ? $"Classified LAS/LAZ loaded: {result.FileCount} file(s) (EPSG:{result.EpsgCode})"
+                : $"Classified LAS/LAZ loaded: {result.FileCount} file(s); enter the projected EPSG code",
             _ => "Elevation data loaded"
         };
         Snackbar.Add(message, Severity.Success);
@@ -1332,6 +1365,7 @@ public partial class GenerateTerrain : IDisposable
         _canFetchOsmData = metadata.CanFetchOsmData;
         _osmBlockedReason = metadata.OsmBlockedReason;
         _geoTiffValidationResult = metadata.ValidationResult;
+        _tileBoundsInfo = metadata.TileBounds;
     }
 
     /// <summary>
@@ -1348,6 +1382,8 @@ public partial class GenerateTerrain : IDisposable
         _geoTiffDirectory = null;
         _state.XyzPath = null;
         _state.XyzFilePaths = null;
+        _state.LidarFilePaths = null;
+        _state.LidarEpsgCode = 0;
 
         // Clear geo metadata
         ClearGeoMetadata();
@@ -1378,6 +1414,8 @@ public partial class GenerateTerrain : IDisposable
         {
             // Update the import result's EPSG code
             _elevationImportResult.EpsgCode = _xyzEpsgCode;
+            if (_elevationImportResult.SourceType == ElevationSourceType.LidarPointCloud)
+                _state.LidarEpsgCode = _xyzEpsgCode;
 
             // Re-read metadata with new EPSG
             var updatedResult =
@@ -1434,6 +1472,8 @@ public partial class GenerateTerrain : IDisposable
             25833 => "ETRS89 / UTM zone 33N (Eastern Germany)",
             32632 => "WGS 84 / UTM zone 32N",
             32633 => "WGS 84 / UTM zone 33N",
+            26913 => "NAD83 / UTM zone 13N (Wyoming)",
+            6342 => "NAD83(2011) / UTM zone 13N (Wyoming)",
             _ => $"EPSG:{_xyzEpsgCode}"
         };
     }
@@ -1448,6 +1488,20 @@ public partial class GenerateTerrain : IDisposable
     {
         _metersPerPixel = newMpp;
         await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnLidarResolutionChanged(float newMpp)
+    {
+        _metersPerPixel = newMpp;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private string GetLidarCoverageDescription()
+    {
+        var coverageKm = _terrainSize * _metersPerPixel / 1000f;
+        return $"{_terrainSize:N0} × {_terrainSize:N0} at {_metersPerPixel:0.##} m covers " +
+               $"{coverageKm:0.###} km × {coverageKm:0.###} km. " +
+               "For a 16.384 km single terrain, use 16,384 at 1.0 m.";
     }
 
     private async Task OnCropAnchorChanged(CropAnchor newAnchor)
@@ -1470,7 +1524,15 @@ public partial class GenerateTerrain : IDisposable
             // CRITICAL: Recalculate elevation range for the cropped region
             // The maxHeight and baseHeight must reflect the cropped area, not the full image
             // This will call StateHasChanged internally when done
-            await RecalculateCroppedElevation(result);
+            if (_heightmapSourceType != HeightmapSourceType.LidarPointCloud)
+                await RecalculateCroppedElevation(result);
+        }
+        else if (!result.NeedsCropping && _heightmapSourceType == HeightmapSourceType.LidarPointCloud)
+        {
+            _maxHeight = 0;
+            if (_geoTiffMinElevation.HasValue)
+                _terrainBaseHeight = (float)_geoTiffMinElevation.Value;
+            await InvokeAsync(StateHasChanged);
         }
         else if (!result.NeedsCropping && _geoTiffMinElevation.HasValue && _geoTiffMaxElevation.HasValue)
         {
@@ -2049,6 +2111,40 @@ public partial class GenerateTerrain : IDisposable
                 {
                     PubSubChannel.SendMessage(PubSubMessageType.Warning,
                         $"XYZ file not found: {result.XyzPath}. Please browse to select the file.");
+                }
+            }
+            else if (result.HeightmapSourceType == HeightmapSourceType.LidarPointCloud &&
+                     result.LidarFilePaths is { Length: > 0 })
+            {
+                _state.LidarFilePaths = result.LidarFilePaths;
+                _state.LidarEpsgCode = result.LidarEpsgCode ?? 0;
+                _xyzEpsgCode = _state.LidarEpsgCode;
+                _geoTiffPath = null;
+                _geoTiffDirectory = null;
+                _state.XyzPath = null;
+                _state.XyzFilePaths = null;
+
+                _elevationImportResult = new ElevationImportResult
+                {
+                    SourceType = ElevationSourceType.LidarPointCloud,
+                    FilePaths = result.LidarFilePaths,
+                    FileNames = result.LidarFilePaths.Select(Path.GetFileName).ToArray()!,
+                    FileCount = result.LidarFilePaths.Length,
+                    FormatLabel = "Classified LAS/LAZ",
+                    NeedsEpsgCode = true,
+                    EpsgCode = _state.LidarEpsgCode,
+                    ResolvedLidarFilePaths = result.LidarFilePaths
+                };
+
+                if (result.LidarFilePaths.All(File.Exists))
+                {
+                    await ReadGeoTiffMetadata(syncMetersPerPixel: false);
+                    geoTiffLoaded = true;
+                }
+                else
+                {
+                    PubSubChannel.SendMessage(PubSubMessageType.Warning,
+                        "One or more LAS/LAZ files from the preset are missing. Re-import the point-cloud tiles.");
                 }
             }
 
@@ -2650,6 +2746,8 @@ public partial class GenerateTerrain : IDisposable
                 _state.XyzFilePaths.Where(path => !string.IsNullOrWhiteSpace(path)).ToList(),
             HeightmapSourceType.XyzFile when !string.IsNullOrWhiteSpace(_state.XyzPath) =>
                 [_state.XyzPath],
+            HeightmapSourceType.LidarPointCloud when _state.LidarFilePaths is { Length: > 0 } =>
+                _state.LidarFilePaths.Where(path => !string.IsNullOrWhiteSpace(path)).ToList(),
             HeightmapSourceType.Png when !string.IsNullOrWhiteSpace(_state.HeightmapPath) =>
                 [_state.HeightmapPath],
             _ => []

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
@@ -9,6 +9,7 @@ using BeamNG_LevelCleanUp.Objects;
 using BeamNG_LevelCleanUp.Objects.MtSettings;
 using BeamNG_LevelCleanUp.Utils;
 using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
 using BeamNgTerrainPoc.Terrain.Logging;
 using BeamNgTerrainPoc.Terrain.Models.DecalRoad;
 using BeamNgTerrainPoc.Terrain.Osm.Models;
@@ -1488,6 +1489,112 @@ public partial class GenerateTerrain : IDisposable
     {
         _metersPerPixel = newMpp;
         await InvokeAsync(StateHasChanged);
+    }
+
+    /// <summary>
+    /// Finds free USGS 3DEP classified LAZ products for the saved/current map bounds,
+    /// downloads selected tiles with resume/cache support, then imports them into the
+    /// existing ground-class DTM workflow.
+    /// </summary>
+    private async Task DownloadUsgsLidar()
+    {
+        var parameters = new DialogParameters<UsgsLidarDownloadDialog>
+        {
+            { x => x.InitialBounds, GetSavedElevationBounds() },
+            { x => x.TerrainSize, _terrainSize },
+            { x => x.MetersPerPixel, (double)_metersPerPixel }
+        };
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            CloseOnEscapeKey = true,
+            BackdropClick = false,
+            MaxWidth = MaxWidth.Large,
+            FullWidth = true
+        };
+
+        var dialog = await DialogService.ShowAsync<UsgsLidarDownloadDialog>(
+            "Find USGS 3DEP Classified Point Clouds",
+            parameters,
+            options);
+        var dialogResult = await dialog.Result;
+        if (dialogResult == null || dialogResult.Canceled ||
+            dialogResult.Data is not UsgsLidarDialogResult request)
+            return;
+
+        _isImportingElevation = true;
+        await InvokeAsync(StateHasChanged);
+
+        try
+        {
+            _elevationImportSnackbar = Snackbar.Add(
+                $"USGS 3DEP: checking cache for {request.Products.Count:N0} LAZ tile(s)...",
+                Severity.Info,
+                config => { config.VisibleStateDuration = int.MaxValue; });
+
+            var progress = new Progress<UsgsLidarDownloadProgress>(update =>
+                PubSubChannel.SendMessage(PubSubMessageType.Info, update.Message));
+
+            UsgsLidarDownloadResult download;
+            using (var service = new UsgsLidarDownloadService())
+            {
+                download = await service.DownloadAsync(
+                    request.Products,
+                    AppPaths.UsgsLidarCacheFolder,
+                    progress,
+                    _disposalCts.Token);
+            }
+
+            var importResult = await _elevationImportService.ImportFilesAsync(download.FilePaths.ToArray());
+            await ApplyImportResult(importResult);
+
+            Snackbar.Add(
+                $"USGS point cloud ready: {download.DownloadedFiles:N0} downloaded, " +
+                $"{download.ReusedFiles:N0} reused from cache. Choose DTM cell size, then generate terrain.",
+                Severity.Success);
+        }
+        catch (OperationCanceledException)
+        {
+            Snackbar.Add("USGS download cancelled. Partial and completed files remain cached for resume.", Severity.Info);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"USGS point-cloud download failed: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            if (_elevationImportSnackbar != null)
+            {
+                Snackbar.Remove(_elevationImportSnackbar);
+                _elevationImportSnackbar = null;
+            }
+
+            _isImportingElevation = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private GeoBoundingBox? GetSavedElevationBounds()
+    {
+        if (EffectiveBoundingBox is { IsValidWgs84: true } current &&
+            current.Width > 0 && current.Height > 0)
+            return current;
+
+        if (string.IsNullOrWhiteSpace(_workingDirectory))
+            return null;
+
+        var geoReference = MtSettings.Load(_workingDirectory)?.GeoReferenceSettings;
+        if (geoReference is not { HasGeoReference: true })
+            return null;
+
+        var bounds = new GeoBoundingBox(
+            geoReference.TerrainMinLongitude,
+            geoReference.TerrainMinLatitude,
+            geoReference.TerrainMaxLongitude,
+            geoReference.TerrainMaxLatitude);
+        return bounds.IsValidWgs84 && bounds.Width > 0 && bounds.Height > 0
+            ? bounds
+            : null;
     }
 
     private async Task OnLidarResolutionChanged(float newMpp)

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/ElevationImportResult.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/ElevationImportResult.cs
@@ -9,7 +9,8 @@ public enum ElevationSourceType
     GeoTiffSingle,
     GeoTiffMultiple,
     XyzFile,
-    XyzMultiple
+    XyzMultiple,
+    LidarPointCloud
 }
 
 /// <summary>
@@ -53,4 +54,5 @@ public class ElevationImportResult
     public string? ResolvedXyzPath { get; init; }
     public string[]? ResolvedXyzFilePaths { get; init; }
     public string? ResolvedHeightmapPath { get; init; }
+    public string[]? ResolvedLidarFilePaths { get; init; }
 }

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/ElevationImportService.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/ElevationImportService.cs
@@ -3,19 +3,21 @@ using BeamNG_LevelCleanUp.Communication;
 using BeamNG_LevelCleanUp.Objects;
 using BeamNG_LevelCleanUp.Utils;
 using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
 
 namespace BeamNG_LevelCleanUp.BlazorUI.Services;
 
 /// <summary>
 ///     Service that orchestrates unified elevation data import.
 ///     Handles format detection, ZIP extraction, EPSG auto-detection, and metadata reading.
-///     Supports GeoTIFF (.tif/.tiff), XYZ ASCII (.xyz/.txt), ZIP archives (.zip), and PNG (.png).
+///     Supports GeoTIFF, XYZ ASCII, classified LAS/LAZ, ZIP archives, and PNG.
 /// </summary>
 public class ElevationImportService
 {
     private static readonly string[] GeoTiffExtensions = [".tif", ".tiff", ".geotiff"];
     private static readonly string[] XyzExtensions = [".xyz", ".txt"];
     private static readonly string[] PngExtensions = [".png"];
+    private static readonly string[] LidarExtensions = [".las", ".laz"];
     private static readonly string[] ZipExtensions = [".zip"];
 
     private readonly GeoTiffMetadataService _metadataService = new();
@@ -53,7 +55,7 @@ public class ElevationImportService
 
         if (resolvedPaths.Count == 0)
             throw new InvalidOperationException(
-                "No supported elevation files found. Supported formats: GeoTIFF (.tif, .tiff), XYZ (.xyz, .txt), PNG (.png).");
+                "No supported elevation files found. Supported formats: GeoTIFF, XYZ, classified LAS/LAZ, and PNG.");
 
         _tempExtractionPath = tempExtractionPath;
 
@@ -73,14 +75,15 @@ public class ElevationImportService
         if (supportedFiles.Length == 0)
             throw new InvalidOperationException(
                 $"No supported elevation files found in '{folderPath}'. " +
-                "Supported extensions: .tif, .tiff, .xyz, .txt, .png");
+                "Supported extensions: .tif, .tiff, .xyz, .txt, .las, .laz, .png");
 
         // Check if all files are the same type
         var geoTiffs = supportedFiles.Where(f => IsGeoTiffFile(f)).ToArray();
         var xyzFiles = supportedFiles.Where(f => IsXyzFile(f)).ToArray();
+        var lidarFiles = supportedFiles.Where(f => IsLidarFile(f)).ToArray();
 
         // Prefer GeoTIFF tiles if found (existing behavior)
-        if (geoTiffs.Length > 0 && xyzFiles.Length == 0)
+        if (geoTiffs.Length > 0 && xyzFiles.Length == 0 && lidarFiles.Length == 0)
         {
             // Use the existing directory-based tile reading
             var metadata = await _metadataService.ReadFromDirectoryAsync(folderPath);
@@ -107,12 +110,19 @@ public class ElevationImportService
     public async Task<ElevationImportResult> ReloadWithEpsgAsync(ElevationImportResult previous, int epsgCode)
     {
         if (previous.SourceType != ElevationSourceType.XyzFile &&
-            previous.SourceType != ElevationSourceType.XyzMultiple)
+            previous.SourceType != ElevationSourceType.XyzMultiple &&
+            previous.SourceType != ElevationSourceType.LidarPointCloud)
             return previous;
 
         GeoTiffMetadataService.GeoTiffMetadataResult? metadata;
 
-        if (previous.SourceType == ElevationSourceType.XyzMultiple &&
+        if (previous.SourceType == ElevationSourceType.LidarPointCloud &&
+            previous.ResolvedLidarFilePaths is { Length: > 0 })
+        {
+            metadata = await _metadataService.ReadFromLidarFilesAsync(
+                previous.ResolvedLidarFilePaths, epsgCode);
+        }
+        else if (previous.SourceType == ElevationSourceType.XyzMultiple &&
             previous.ResolvedXyzFilePaths is { Length: > 1 })
         {
             // Multiple XYZ tiles — read combined metadata from all tiles
@@ -143,7 +153,8 @@ public class ElevationImportService
             TempExtractionPath = previous.TempExtractionPath,
             WasExtractedFromZip = previous.WasExtractedFromZip,
             ResolvedXyzPath = previous.ResolvedXyzPath,
-            ResolvedXyzFilePaths = previous.ResolvedXyzFilePaths
+            ResolvedXyzFilePaths = previous.ResolvedXyzFilePaths,
+            ResolvedLidarFilePaths = previous.ResolvedLidarFilePaths
         };
     }
 
@@ -173,19 +184,51 @@ public class ElevationImportService
         var geoTiffs = filePaths.Where(IsGeoTiffFile).ToArray();
         var xyzFiles = filePaths.Where(IsXyzFile).ToArray();
         var pngFiles = filePaths.Where(IsPngFile).ToArray();
+        var lidarFiles = filePaths.Where(IsLidarFile).ToArray();
 
         // Validate: don't mix formats
         var formatCount = (geoTiffs.Length > 0 ? 1 : 0) +
                           (xyzFiles.Length > 0 ? 1 : 0) +
-                          (pngFiles.Length > 0 ? 1 : 0);
+                          (pngFiles.Length > 0 ? 1 : 0) +
+                          (lidarFiles.Length > 0 ? 1 : 0);
 
         if (formatCount > 1)
             throw new InvalidOperationException(
-                "Mixed file formats detected. Please select files of a single format (GeoTIFF, XYZ, or PNG).");
+                "Mixed file formats detected. Please select one format (GeoTIFF, XYZ, LAS/LAZ, or PNG).");
 
         if (formatCount == 0)
             throw new InvalidOperationException(
-                "No supported elevation files found. Supported: .tif, .tiff, .xyz, .txt, .png");
+                "No supported elevation files found. Supported: .tif, .tiff, .xyz, .txt, .las, .laz, .png");
+
+        // Classified LAS/LAZ point cloud
+        if (lidarFiles.Length > 0)
+        {
+            var pointCloudInfo = await Task.Run(() =>
+                new LidarPointCloudReader().ReadInfo(lidarFiles));
+            var epsgCode = pointCloudInfo.EpsgCode ?? 0;
+            var metadata = await _metadataService.ReadFromLidarFilesAsync(lidarFiles, epsgCode);
+
+            PubSubChannel.SendMessage(PubSubMessageType.Info,
+                epsgCode > 0
+                    ? $"Detected EPSG:{epsgCode} from LAS/LAZ projection metadata"
+                    : "LAS/LAZ projection was not embedded; enter its projected EPSG code");
+
+            return new ElevationImportResult
+            {
+                SourceType = ElevationSourceType.LidarPointCloud,
+                FilePaths = lidarFiles,
+                FileNames = lidarFiles.Select(Path.GetFileName).ToArray()!,
+                FileCount = lidarFiles.Length,
+                FormatLabel = "Classified LAS/LAZ",
+                Metadata = metadata,
+                NeedsEpsgCode = true,
+                DetectedEpsgCode = pointCloudInfo.EpsgCode,
+                EpsgCode = epsgCode,
+                TempExtractionPath = tempExtractionPath,
+                WasExtractedFromZip = wasZip,
+                ResolvedLidarFilePaths = lidarFiles
+            };
+        }
 
         // PNG
         if (pngFiles.Length > 0)
@@ -353,7 +396,7 @@ public class ElevationImportService
     private static string[] ScanDirectoryForSupportedFiles(string directoryPath)
     {
         return Directory.GetFiles(directoryPath, "*", SearchOption.AllDirectories)
-            .Where(f => IsGeoTiffFile(f) || IsXyzFile(f) || IsPngFile(f))
+            .Where(f => IsGeoTiffFile(f) || IsXyzFile(f) || IsLidarFile(f) || IsPngFile(f))
             .OrderBy(f => f)
             .ToArray();
     }
@@ -374,6 +417,12 @@ public class ElevationImportService
     {
         var ext = Path.GetExtension(path).ToLowerInvariant();
         return PngExtensions.Contains(ext);
+    }
+
+    private static bool IsLidarFile(string path)
+    {
+        var ext = Path.GetExtension(path).ToLowerInvariant();
+        return LidarExtensions.Contains(ext);
     }
 
     private static bool IsZipFile(string path)

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/GeoTiffMetadataService.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/GeoTiffMetadataService.cs
@@ -1,6 +1,7 @@
 using BeamNG_LevelCleanUp.Communication;
 using BeamNG_LevelCleanUp.Objects;
 using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
 using OSGeo.GDAL;
 using OSGeo.OSR;
 
@@ -608,6 +609,44 @@ public class GeoTiffMetadataService
             $"GeoTIFF: {info.Width}x{info.Height}px, terrain size will be {suggestedTerrainSize}");
         PubSubChannel.SendMessage(PubSubMessageType.Info,
             $"Projection: {info.ProjectionName}");
+    }
+
+    /// <summary>
+    ///     Reads LAS/LAZ header metadata without decompressing the full point cloud.
+    ///     Elevation limits are header limits (all classes); the exact class-2 range is
+    ///     calculated while the DTM is generated.
+    /// </summary>
+    public async Task<GeoTiffMetadataResult> ReadFromLidarFilesAsync(
+        string[] filePaths,
+        int epsgCode = 0,
+        float metadataCellSizeMeters = LidarPointCloudReader.DefaultMetadataCellSizeMeters)
+    {
+        var info = await Task.Run(() =>
+            new LidarPointCloudReader().ReadInfo(filePaths, epsgCode, metadataCellSizeMeters));
+        var canFetchOsm = info.Wgs84BoundingBox?.IsValidWgs84 == true;
+
+        PubSubChannel.SendMessage(PubSubMessageType.Info,
+            $"LAS/LAZ: {info.FilePaths.Length} tile(s), {info.PointCount:N0} points, " +
+            $"extent grid {info.PreviewWidth}x{info.PreviewHeight} at {metadataCellSizeMeters:F2}m");
+
+        return new GeoTiffMetadataResult
+        {
+            Wgs84BoundingBox = info.Wgs84BoundingBox,
+            NativeBoundingBox = info.NativeBoundingBox,
+            ProjectionName = info.ProjectionName,
+            ProjectionWkt = info.ProjectionWkt,
+            GeoTransform = info.GeoTransform,
+            OriginalWidth = info.PreviewWidth,
+            OriginalHeight = info.PreviewHeight,
+            MinElevation = info.HeaderMinElevationMeters,
+            MaxElevation = info.HeaderMaxElevationMeters,
+            SuggestedTerrainSize = GetNearestPowerOfTwo(Math.Max(info.PreviewWidth, info.PreviewHeight)),
+            CanFetchOsmData = canFetchOsm,
+            OsmBlockedReason = !canFetchOsm
+                ? "LAS/LAZ requires the correct projected EPSG code before OSM coordinates can be calculated"
+                : null,
+            TileBounds = info.TileBounds
+        };
     }
 
     public static int GetNearestPowerOfTwo(int value)

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainAnalysisOrchestrator.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainAnalysisOrchestrator.cs
@@ -4,6 +4,7 @@ using BeamNG_LevelCleanUp.BlazorUI.State;
 using BeamNG_LevelCleanUp.Communication;
 using BeamNG_LevelCleanUp.Objects;
 using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
 using BeamNgTerrainPoc.Terrain.Models;
 using BeamNgTerrainPoc.Terrain.Models.RoadGeometry;
 using BeamNgTerrainPoc.Terrain.Osm.Models;
@@ -422,6 +423,7 @@ public class TerrainAnalysisOrchestrator
                 HeightmapSourceType.Png => await LoadPngHeightMapAsync(state.HeightmapPath, state.MaxHeight),
                 HeightmapSourceType.GeoTiffFile => await LoadGeoTiffHeightMapAsync(state),
                 HeightmapSourceType.GeoTiffDirectory => await LoadGeoTiffDirectoryHeightMapAsync(state),
+                HeightmapSourceType.LidarPointCloud => await LoadLidarHeightMapAsync(state),
                 _ => null
             };
         }
@@ -451,6 +453,33 @@ public class TerrainAnalysisOrchestrator
             }
 
             return heightMap;
+        });
+    }
+
+    private static async Task<float[,]?> LoadLidarHeightMapAsync(TerrainGenerationState state)
+    {
+        if (state.LidarFilePaths is not { Length: > 0 } || state.LidarEpsgCode <= 0)
+            return null;
+
+        return await Task.Run(() =>
+        {
+            var crop = state.CropResult is { NeedsCropping: true };
+            var dtm = new LidarPointCloudReader().CreateGroundDtm(
+                state.LidarFilePaths,
+                state.LidarEpsgCode,
+                state.TerrainSize,
+                state.MetersPerPixel,
+                state.LidarGroundClassification,
+                crop,
+                crop ? state.CropResult!.OffsetX : 0,
+                crop ? state.CropResult!.OffsetY : 0,
+                state.LidarMetadataCellSizeMeters);
+            using var image = dtm.HeightmapImage;
+
+            return ConvertImageToHeightMap(
+                image,
+                dtm.MinElevation,
+                dtm.MaxElevation);
         });
     }
 

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainGenerationOrchestrator.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainGenerationOrchestrator.cs
@@ -1120,6 +1120,15 @@ public class TerrainGenerationOrchestrator
 
                 parameters.XyzEpsgCode = state.XyzEpsgCode;
                 break;
+
+            case HeightmapSourceType.LidarPointCloud:
+                parameters.LidarFilePaths = state.LidarFilePaths;
+                parameters.LidarEpsgCode = state.LidarEpsgCode;
+                parameters.LidarGroundClassification = state.LidarGroundClassification;
+                parameters.LidarMetadataCellSizeMeters = state.LidarMetadataCellSizeMeters;
+                parameters.ExportLidarDtmHeightmap = true;
+                ApplyCropSettings(state, parameters);
+                break;
         }
 
         return parameters;

--- a/BeamNG_LevelCleanUp/BlazorUI/State/TerrainGenerationState.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/State/TerrainGenerationState.cs
@@ -156,6 +156,10 @@ public class TerrainGenerationState
     public string[]? XyzFilePaths { get; set; }
     public int XyzEpsgCode { get; set; } = 25832;
     public int? XyzDetectedEpsg { get; set; }
+    public string[]? LidarFilePaths { get; set; }
+    public int LidarEpsgCode { get; set; }
+    public byte LidarGroundClassification { get; set; } = 2;
+    public float LidarMetadataCellSizeMeters { get; set; } = 0.5f;
 
     /// <summary>
     ///     Per-tile bounding boxes for filtering tiles before combine operations.
@@ -285,6 +289,9 @@ public class TerrainGenerationState
             HeightmapSourceType.XyzFile => ((!string.IsNullOrEmpty(XyzPath) && File.Exists(XyzPath)) ||
                                             (XyzFilePaths is { Length: > 0 })) &&
                                            XyzEpsgCode > 0,
+            HeightmapSourceType.LidarPointCloud => LidarFilePaths is { Length: > 0 } &&
+                                                   LidarFilePaths.All(File.Exists) &&
+                                                   LidarEpsgCode > 0,
             _ => false
         };
 
@@ -313,6 +320,7 @@ public class TerrainGenerationState
             HeightmapSourceType.GeoTiffFile => "Single GeoTIFF elevation file with geographic coordinates",
             HeightmapSourceType.GeoTiffDirectory => "Directory with multiple GeoTIFF tiles to combine",
             HeightmapSourceType.XyzFile => "XYZ ASCII elevation file (georeferenced grid data)",
+            HeightmapSourceType.LidarPointCloud => "Classified LAS/LAZ ground points rasterized to a 16-bit DTM",
             _ => "Unknown"
         };
     }
@@ -410,6 +418,10 @@ public class TerrainGenerationState
         XyzFilePaths = null;
         XyzEpsgCode = 25832;
         XyzDetectedEpsg = null;
+        LidarFilePaths = null;
+        LidarEpsgCode = 0;
+        LidarGroundClassification = 2;
+        LidarMetadataCellSizeMeters = 0.5f;
         CropAnchor = CropAnchor.Center;
         CropResult = null;
         CanFetchOsmData = false;

--- a/BeamNG_LevelCleanUp/Utils/AppPaths.cs
+++ b/BeamNG_LevelCleanUp/Utils/AppPaths.cs
@@ -39,6 +39,12 @@ public static class AppPaths
     public static string LogsFolder => Path.Combine(AppDataFolder, "logs");
 
     /// <summary>
+    /// Persistent cache for free USGS 3DEP LAS/LAZ downloads. Completed files and
+    /// partial downloads are retained so large point-cloud acquisitions can resume.
+    /// </summary>
+    public static string UsgsLidarCacheFolder => Path.Combine(AppDataFolder, "cache", "usgs-3dep-lidar");
+
+    /// <summary>
     /// Settings folder (already used by WindowSettings).
     /// C:\Users\{username}\AppData\Local\BeamNG_LevelCleanUp
     /// </summary>
@@ -79,6 +85,7 @@ public static class AppPaths
     {
         Directory.CreateDirectory(TempFolder);
         Directory.CreateDirectory(LogsFolder);
+        Directory.CreateDirectory(UsgsLidarCacheFolder);
         
         // On application startup, clean up any stale temp folders from previous sessions
         // This prevents accumulation of temp files and ensures a fresh state

--- a/BeamNgTerrainPoc.Tests/Lidar/LidarPointCloudReaderTests.cs
+++ b/BeamNgTerrainPoc.Tests/Lidar/LidarPointCloudReaderTests.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using BeamNgTerrainPoc.Terrain.Lidar;
+
+namespace BeamNgTerrainPoc.Tests.Lidar;
+
+public class LidarPointCloudReaderTests
+{
+    [Fact]
+    public void Las14PointFormatsUseExtendedClassification()
+    {
+        Assert.Equal((byte)2, LasZipNativeReader.SelectClassification(6, 0, 2));
+        Assert.Equal((byte)2, LasZipNativeReader.SelectClassification(10, 0, 2));
+        Assert.Equal((byte)2, LasZipNativeReader.SelectClassification(3, 2, 0));
+    }
+
+    [Fact]
+    public void FillMissingCellsInterpolatesRowsAndColumns()
+    {
+        const int size = 4;
+        var samples = new ushort[size * size];
+        var populated = new BitArray(samples.Length);
+
+        Set(1, 1, 0);
+        Set(3, 1, 100);
+        Set(1, 3, 200);
+        Set(3, 3, 300);
+
+        LidarPointCloudReader.FillMissingCells(samples, populated, size);
+
+        Assert.Equal(new ushort[] { 0, 0, 50, 100 }, samples[0..4]);
+        Assert.Equal(new ushort[] { 0, 0, 50, 100 }, samples[4..8]);
+        Assert.Equal(new ushort[] { 100, 100, 150, 200 }, samples[8..12]);
+        Assert.Equal(new ushort[] { 200, 200, 250, 300 }, samples[12..16]);
+        return;
+
+        void Set(int x, int y, ushort value)
+        {
+            var index = y * size + x;
+            samples[index] = value;
+            populated[index] = true;
+        }
+    }
+
+    [Fact]
+    public void FillMissingCellsRejectsEmptyGrid()
+    {
+        var samples = new ushort[16];
+        var populated = new BitArray(16);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            LidarPointCloudReader.FillMissingCells(samples, populated, 4));
+    }
+}

--- a/BeamNgTerrainPoc.Tests/Lidar/UsgsLidarDownloadServiceTests.cs
+++ b/BeamNgTerrainPoc.Tests/Lidar/UsgsLidarDownloadServiceTests.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using BeamNgTerrainPoc.Terrain.GeoTiff;
+using BeamNgTerrainPoc.Terrain.Lidar;
+
+namespace BeamNgTerrainPoc.Tests.Lidar;
+
+public class UsgsLidarDownloadServiceTests
+{
+    private static readonly GeoBoundingBox WestonBounds = new(-104.95, 43.70, -104.70, 43.95);
+
+    [Fact]
+    public void SearchUriTargetsLpcLazWithinRequestedBounds()
+    {
+        var uri = UsgsLidarDownloadService.BuildSearchUri(WestonBounds, 100, 0);
+        var decoded = Uri.UnescapeDataString(uri.Query);
+
+        Assert.Equal("tnmaccess.nationalmap.gov", uri.Host);
+        Assert.Contains("bbox=-104.95,43.7,-104.7,43.95", decoded);
+        Assert.Contains("datasets=Lidar Point Cloud (LPC)", decoded);
+        Assert.Contains("prodFormats=LAS,LAZ", decoded);
+        Assert.Contains("max=100", decoded);
+        Assert.Contains("offset=0", decoded);
+    }
+
+    [Fact]
+    public void SquareBoundsMatchRequestedGroundDimensions()
+    {
+        var bounds = UsgsLidarDownloadService.BuildSquareBounds(43.8, -104.85, 16_384);
+
+        Assert.InRange(bounds.ApproximateWidthMeters, 16_300, 16_470);
+        Assert.InRange(bounds.ApproximateHeightMeters, 16_300, 16_470);
+        Assert.Equal(43.8, bounds.Center.Latitude, 6);
+        Assert.Equal(-104.85, bounds.Center.Longitude, 6);
+    }
+
+    [Fact]
+    public async Task SearchRetriesGatewayTimeoutAndUsesConservativePages()
+    {
+        var handler = new SequenceHandler(
+            () => new HttpResponseMessage(HttpStatusCode.GatewayTimeout),
+            () => JsonResponse(SingleProductSearchJson));
+        using var client = new HttpClient(handler);
+        using var service = new UsgsLidarDownloadService(client, (_, _) => Task.CompletedTask);
+        var progress = new CollectingProgress<string>();
+
+        var result = await service.SearchAsync(WestonBounds, progress);
+
+        var product = Assert.Single(result.Products);
+        Assert.Equal("inside", product.SourceId);
+        Assert.Equal(2, handler.RequestCount);
+        Assert.All(handler.RequestUris, uri =>
+        {
+            var decoded = Uri.UnescapeDataString(uri.Query);
+            Assert.Contains("prodFormats=LAS,LAZ", decoded);
+            Assert.Contains("max=100", decoded);
+        });
+        Assert.Contains(progress.Values, message => message.Contains("504", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task SearchRetriesHttp200CatalogErrorPayload()
+    {
+        var handler = new SequenceHandler(
+            () => JsonResponse("""{"error":"ScienceBase inventory is busy"}"""),
+            () => JsonResponse(SingleProductSearchJson));
+        using var client = new HttpClient(handler);
+        using var service = new UsgsLidarDownloadService(client, (_, _) => Task.CompletedTask);
+
+        var result = await service.SearchAsync(WestonBounds);
+
+        Assert.Single(result.Products);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task SearchDoesNotRetryNonTransientClientError()
+    {
+        var handler = new SequenceHandler(
+            () => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        using var client = new HttpClient(handler);
+        using var service = new UsgsLidarDownloadService(client, (_, _) => Task.CompletedTask);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => service.SearchAsync(WestonBounds));
+
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public void SearchResponseKeepsIntersectingHttpsLazProducts()
+    {
+        const string json = """
+                            {
+                              "total": 3,
+                              "items": [
+                                {
+                                  "sourceId": "inside",
+                                  "title": "USGS LAZ inside",
+                                  "sizeInBytes": 300,
+                                  "downloadLazURL": "https://example.gov/inside.laz",
+                                  "publicationDate": "2025-01-02",
+                                  "boundingBox": { "minX": -104.90, "minY": 43.75, "maxX": -104.80, "maxY": 43.85 }
+                                },
+                                {
+                                  "sourceId": "outside",
+                                  "title": "outside",
+                                  "downloadLazURL": "https://example.gov/outside.laz",
+                                  "boundingBox": { "minX": -100, "minY": 40, "maxX": -99, "maxY": 41 }
+                                },
+                                {
+                                  "sourceId": "insecure",
+                                  "title": "insecure",
+                                  "downloadLazURL": "http://example.gov/insecure.laz",
+                                  "boundingBox": { "minX": -104.90, "minY": 43.75, "maxX": -104.80, "maxY": 43.85 }
+                                }
+                              ]
+                            }
+                            """;
+
+        var page = UsgsLidarDownloadService.ParseSearchResponse(json, WestonBounds);
+
+        Assert.Equal(3, page.TotalAvailable);
+        Assert.Equal(3, page.RawItemCount);
+        var product = Assert.Single(page.Products);
+        Assert.Equal("inside", product.SourceId);
+        Assert.Equal(300, product.SizeInBytes);
+    }
+
+    [Fact]
+    public async Task CompletedLazFileIsReusedFromPersistentCache()
+    {
+        var payload = new byte[300];
+        Encoding.ASCII.GetBytes("LASF").CopyTo(payload, 0);
+        var handler = new CountingHandler(payload);
+        using var client = new HttpClient(handler);
+        using var service = new UsgsLidarDownloadService(client);
+        var cache = Path.Combine(Path.GetTempPath(), "BeamNgUsgsTest", Guid.NewGuid().ToString("N"));
+        var product = new UsgsLidarProduct(
+            "test",
+            "test tile",
+            new Uri("https://example.gov/tile.laz"),
+            payload.Length,
+            WestonBounds,
+            null);
+
+        try
+        {
+            var first = await service.DownloadAsync([product], cache);
+            var second = await service.DownloadAsync([product], cache);
+
+            Assert.Equal(1, handler.RequestCount);
+            Assert.Equal(1, first.DownloadedFiles);
+            Assert.Equal(1, second.ReusedFiles);
+            Assert.Equal(first.FilePaths, second.FilePaths);
+        }
+        finally
+        {
+            if (Directory.Exists(cache)) Directory.Delete(cache, true);
+        }
+    }
+
+    [Fact]
+    public async Task IncompleteDownloadAutomaticallyResumesOnNextAttempt()
+    {
+        var payload = new byte[300];
+        Encoding.ASCII.GetBytes("LASF").CopyTo(payload, 0);
+        var handler = new ResumableDownloadHandler(payload, 150);
+        using var client = new HttpClient(handler);
+        using var service = new UsgsLidarDownloadService(client, (_, _) => Task.CompletedTask);
+        var cache = Path.Combine(Path.GetTempPath(), "BeamNgUsgsTest", Guid.NewGuid().ToString("N"));
+        var product = new UsgsLidarProduct(
+            "resume-test",
+            "resume test tile",
+            new Uri("https://example.gov/resume.laz"),
+            payload.Length,
+            WestonBounds,
+            null);
+
+        try
+        {
+            var result = await service.DownloadAsync([product], cache);
+
+            Assert.Equal(1, result.DownloadedFiles);
+            Assert.Equal(2, handler.RequestCount);
+            Assert.Equal(150, handler.SecondRequestRangeStart);
+            Assert.Equal(payload, await File.ReadAllBytesAsync(Assert.Single(result.FilePaths)));
+            Assert.Empty(Directory.GetFiles(cache, "*.partial"));
+        }
+        finally
+        {
+            if (Directory.Exists(cache)) Directory.Delete(cache, true);
+        }
+    }
+
+    private sealed class CountingHandler(byte[] payload) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(payload)
+            });
+        }
+    }
+
+    private const string SingleProductSearchJson = """
+        {
+          "total": 1,
+          "items": [
+            {
+              "sourceId": "inside",
+              "title": "USGS LAZ inside",
+              "sizeInBytes": 300,
+              "downloadLazURL": "https://example.gov/inside.laz",
+              "publicationDate": "2025-01-02",
+              "boundingBox": { "minX": -104.90, "minY": 43.75, "maxX": -104.80, "maxY": 43.85 }
+            }
+          ]
+        }
+        """;
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+    };
+
+    private sealed class SequenceHandler(params Func<HttpResponseMessage>[] responses) : HttpMessageHandler
+    {
+        private int _index;
+        public int RequestCount { get; private set; }
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            RequestUris.Add(request.RequestUri!);
+            var response = responses[Math.Min(_index, responses.Length - 1)]();
+            _index++;
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ResumableDownloadHandler(byte[] payload, int firstResponseLength) : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+        public long? SecondRequestRangeStart { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (RequestCount == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(payload[..firstResponseLength])
+                });
+            }
+
+            SecondRequestRangeStart = request.Headers.Range?.Ranges.Single().From;
+            var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(payload[firstResponseLength..])
+            };
+            response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                firstResponseLength,
+                payload.Length - 1,
+                payload.Length);
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class CollectingProgress<T> : IProgress<T>
+    {
+        public List<T> Values { get; } = [];
+        public void Report(T value) => Values.Add(value);
+    }
+}

--- a/BeamNgTerrainPoc/BeamNgTerrainPoc.csproj
+++ b/BeamNgTerrainPoc/BeamNgTerrainPoc.csproj
@@ -5,6 +5,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>$(BeamNgMappingVersion)</AssemblyVersion>
     <FileVersion>$(BeamNgMappingVersion)</FileVersion>
   </PropertyGroup>
@@ -18,6 +19,7 @@
     <PackageReference Include="MaxRev.Gdal.Core" Version="3.12.2.472" />
     <PackageReference Include="MaxRev.Gdal.WindowsRuntime.Minimal" Version="3.12.2.472" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
+    <PackageReference Include="LasZipNetStandard" Version="1.1.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.0" />

--- a/BeamNgTerrainPoc/Terrain/Lidar/LasProjectionReader.cs
+++ b/BeamNgTerrainPoc/Terrain/Lidar/LasProjectionReader.cs
@@ -1,0 +1,124 @@
+using System.Text;
+using OSGeo.OSR;
+
+namespace BeamNgTerrainPoc.Terrain.Lidar;
+
+/// <summary>
+///     Reads projection VLRs from the uncompressed LAS/LAZ header area.
+/// </summary>
+internal static class LasProjectionReader
+{
+    private const ushort GeographicTypeGeoKey = 2048;
+    private const ushort ProjectedCrsTypeGeoKey = 3072;
+
+    public static int? TryReadEpsg(string path)
+    {
+        try
+        {
+            using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new BinaryReader(stream, Encoding.ASCII, leaveOpen: false);
+
+            if (Encoding.ASCII.GetString(reader.ReadBytes(4)) != "LASF")
+                return null;
+
+            stream.Position = 94;
+            var headerSize = reader.ReadUInt16();
+            var pointDataOffset = reader.ReadUInt32();
+            var vlrCount = reader.ReadUInt32();
+            stream.Position = headerSize;
+
+            int? geoKeyEpsg = null;
+
+            for (uint i = 0; i < vlrCount && stream.Position + 54 <= pointDataOffset; i++)
+            {
+                reader.ReadUInt16(); // reserved
+                var userId = ReadFixedString(reader, 16);
+                var recordId = reader.ReadUInt16();
+                var length = reader.ReadUInt16();
+                reader.ReadBytes(32); // description
+
+                if (stream.Position + length > stream.Length)
+                    break;
+
+                var data = reader.ReadBytes(length);
+
+                if (userId.Equals("LASF_Projection", StringComparison.OrdinalIgnoreCase) && recordId == 2112)
+                {
+                    var wkt = Encoding.UTF8.GetString(data).TrimEnd('\0', ' ', '\r', '\n');
+                    var epsg = TryGetEpsgFromWkt(wkt);
+                    if (epsg.HasValue)
+                        return epsg;
+                }
+
+                if (userId.Equals("LASF_Projection", StringComparison.OrdinalIgnoreCase) && recordId == 34735)
+                    geoKeyEpsg = TryGetEpsgFromGeoKeys(data) ?? geoKeyEpsg;
+            }
+
+            return geoKeyEpsg;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string ReadFixedString(BinaryReader reader, int length) =>
+        Encoding.ASCII.GetString(reader.ReadBytes(length)).TrimEnd('\0', ' ');
+
+    private static int? TryGetEpsgFromWkt(string wkt)
+    {
+        if (string.IsNullOrWhiteSpace(wkt))
+            return null;
+
+        try
+        {
+            var srs = new SpatialReference(null);
+            var copy = wkt;
+            if (srs.ImportFromWkt(ref copy) != 0)
+                return null;
+
+            srs.AutoIdentifyEPSG();
+            var code = srs.GetAuthorityCode(null) ??
+                       srs.GetAuthorityCode("PROJCS") ??
+                       srs.GetAuthorityCode("GEOGCS");
+            return int.TryParse(code, out var epsg) ? epsg : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static int? TryGetEpsgFromGeoKeys(byte[] data)
+    {
+        if (data.Length < 8 || data.Length % 2 != 0)
+            return null;
+
+        var values = new ushort[data.Length / 2];
+        Buffer.BlockCopy(data, 0, values, 0, data.Length);
+        var keyCount = values[3];
+
+        int? geographic = null;
+        for (var i = 0; i < keyCount; i++)
+        {
+            var offset = 4 + i * 4;
+            if (offset + 3 >= values.Length)
+                break;
+
+            var keyId = values[offset];
+            var tagLocation = values[offset + 1];
+            var count = values[offset + 2];
+            var value = values[offset + 3];
+
+            if (tagLocation != 0 || count != 1 || value is 0 or 32767)
+                continue;
+
+            if (keyId == ProjectedCrsTypeGeoKey)
+                return value;
+            if (keyId == GeographicTypeGeoKey)
+                geographic = value;
+        }
+
+        return geographic;
+    }
+}

--- a/BeamNgTerrainPoc/Terrain/Lidar/LasZipNativeReader.cs
+++ b/BeamNgTerrainPoc/Terrain/Lidar/LasZipNativeReader.cs
@@ -1,0 +1,186 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace BeamNgTerrainPoc.Terrain.Lidar;
+
+/// <summary>
+///     Small streaming wrapper over LASzip's native reader. We read the native point structure
+///     directly so LAS 1.4 extended classifications (point formats 6-10) are handled correctly.
+/// </summary>
+internal sealed unsafe class LasZipNativeReader : IDisposable
+{
+    private const string LasZipLibrary = "laszip64";
+
+    private IntPtr _reader;
+    private LasZipPointNative* _point;
+    private bool _isOpen;
+
+    public LasZipHeader Header { get; private set; }
+
+    public ulong PointCount => Math.Max(Header.NumberOfPointRecords, Header.ExtendedNumberOfPointRecords);
+
+    public byte PointFormat => (byte)(Header.PointDataFormat & 0x3f);
+
+    public void Open(string path)
+    {
+        if (_reader != IntPtr.Zero)
+            throw new InvalidOperationException("LASzip reader is already open.");
+
+        if (laszip_create(ref _reader) != 0 || _reader == IntPtr.Zero)
+            throw new InvalidOperationException("LASzip could not create a reader.");
+
+        var compressed = false;
+        if (laszip_open_reader(_reader, path, ref compressed) != 0)
+        {
+            Dispose();
+            throw new InvalidDataException($"LASzip could not open '{path}'.");
+        }
+
+        _isOpen = true;
+
+        var headerPointer = IntPtr.Zero;
+        if (laszip_get_header_pointer(_reader, ref headerPointer) != 0 || headerPointer == IntPtr.Zero)
+            throw new InvalidDataException($"LASzip could not read the header from '{path}'.");
+
+        Header = Marshal.PtrToStructure<LasZipHeader>(headerPointer);
+
+        var pointPointer = IntPtr.Zero;
+        if (laszip_get_point_pointer(_reader, ref pointPointer) != 0 || pointPointer == IntPtr.Zero)
+            throw new InvalidDataException($"LASzip could not access point records in '{path}'.");
+
+        _point = (LasZipPointNative*)pointPointer;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ReadPoint(out double x, out double y, out double z, out byte classification)
+    {
+        if (!_isOpen || _point == null)
+            throw new InvalidOperationException("LASzip reader is not open.");
+
+        if (laszip_read_point(_reader) != 0)
+        {
+            x = y = z = 0;
+            classification = 0;
+            return false;
+        }
+
+        x = _point->X * Header.ScaleFactorX + Header.OffsetX;
+        y = _point->Y * Header.ScaleFactorY + Header.OffsetY;
+        z = _point->Z * Header.ScaleFactorZ + Header.OffsetZ;
+
+        // LAS 1.4 point formats 6-10 moved classification to the extended byte.
+        classification = SelectClassification(
+            PointFormat, _point->Classification, _point->ExtendedClassification);
+        return true;
+    }
+
+    internal static byte SelectClassification(byte pointFormat, byte legacyClassification, byte extendedClassification) =>
+        pointFormat >= 6 ? extendedClassification : legacyClassification;
+
+    public void Dispose()
+    {
+        if (_reader == IntPtr.Zero)
+            return;
+
+        if (_isOpen)
+            laszip_close_reader(_reader);
+        laszip_destroy(_reader);
+
+        _reader = IntPtr.Zero;
+        _point = null;
+        _isOpen = false;
+    }
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_create(ref IntPtr pointer);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    private static extern int laszip_open_reader(IntPtr pointer, string fileName, ref bool isCompressed);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_get_header_pointer(IntPtr pointer, ref IntPtr headerPointer);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_get_point_pointer(IntPtr pointer, ref IntPtr pointPointer);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_read_point(IntPtr pointer);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_close_reader(IntPtr pointer);
+
+    [DllImport(LasZipLibrary, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int laszip_destroy(IntPtr pointer);
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct LasZipHeader
+    {
+        public ushort FileSourceId;
+        public ushort GlobalEncoding;
+        public uint ProjectId1;
+        public ushort ProjectId2;
+        public ushort ProjectId3;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)] public byte[] ProjectId4;
+        public byte VersionMajor;
+        public byte VersionMinor;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)] public byte[] SystemIdentifier;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)] public byte[] GeneratingSoftware;
+        public ushort CreationDayOfYear;
+        public ushort CreationYear;
+        public ushort HeaderSize;
+        public uint OffsetToPointData;
+        public uint NumberOfVariableLengthRecords;
+        public byte PointDataFormat;
+        public ushort PointDataRecordLength;
+        public uint NumberOfPointRecords;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)] public uint[] NumberOfPointsByReturn;
+        public double ScaleFactorX;
+        public double ScaleFactorY;
+        public double ScaleFactorZ;
+        public double OffsetX;
+        public double OffsetY;
+        public double OffsetZ;
+        public double MaxX;
+        public double MinX;
+        public double MaxY;
+        public double MinY;
+        public double MaxZ;
+        public double MinZ;
+        public ulong StartOfWaveformDataPacketRecord;
+        public ulong StartOfFirstExtendedVariableLengthRecord;
+        public uint NumberOfExtendedVariableLengthRecords;
+        public ulong ExtendedNumberOfPointRecords;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 15)] public ulong[] ExtendedNumberOfPointsByReturn;
+        public uint UserDataInHeaderSize;
+        public IntPtr UserDataInHeader;
+        public IntPtr Vlrs;
+        public uint UserDataAfterHeaderSize;
+        public IntPtr UserDataAfterHeader;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct LasZipPointNative
+    {
+        public int X;
+        public int Y;
+        public int Z;
+        public ushort Intensity;
+        private byte _returnBits;
+        private byte _classificationBits;
+        public sbyte ScanAngleRank;
+        public byte UserData;
+        public ushort PointSourceId;
+        public short ExtendedScanAngle;
+        private byte _extendedFlags;
+        public byte ExtendedClassification;
+        private byte _extendedReturnBits;
+        private fixed byte _dummy[7];
+        public double GpsTime;
+        private fixed ushort _rgb[4];
+        private fixed byte _wavePacket[29];
+        public int NumExtraBytes;
+        public IntPtr ExtraBytes;
+
+        public byte Classification => (byte)(_classificationBits & 0x1f);
+    }
+}

--- a/BeamNgTerrainPoc/Terrain/Lidar/LidarPointCloudReader.cs
+++ b/BeamNgTerrainPoc/Terrain/Lidar/LidarPointCloudReader.cs
@@ -1,0 +1,456 @@
+using System.Collections;
+using BeamNgTerrainPoc.Terrain.GeoTiff;
+using OSGeo.OSR;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace BeamNgTerrainPoc.Terrain.Lidar;
+
+/// <summary>
+///     Streams classified LAS/LAZ tiles and creates a ground-only digital terrain model.
+/// </summary>
+public sealed class LidarPointCloudReader
+{
+    public const float DefaultMetadataCellSizeMeters = 0.5f;
+
+    public sealed class PointCloudInfo
+    {
+        public required string[] FilePaths { get; init; }
+        public required GeoBoundingBox NativeBoundingBox { get; init; }
+        public GeoBoundingBox? Wgs84BoundingBox { get; init; }
+        public required List<TileBoundsInfo> TileBounds { get; init; }
+        public string? ProjectionWkt { get; init; }
+        public string? ProjectionName { get; init; }
+        public int? EpsgCode { get; init; }
+        public double LinearUnitToMeters { get; init; } = 1.0;
+        public ulong PointCount { get; init; }
+        public double HeaderMinElevationMeters { get; init; }
+        public double HeaderMaxElevationMeters { get; init; }
+        public int PreviewWidth { get; init; }
+        public int PreviewHeight { get; init; }
+        public double[] GeoTransform { get; init; } = [];
+    }
+
+    public PointCloudInfo ReadInfo(
+        IEnumerable<string> filePaths,
+        int epsgCode = 0,
+        float metadataCellSizeMeters = DefaultMetadataCellSizeMeters)
+    {
+        var paths = filePaths.Where(File.Exists).Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        if (paths.Length == 0)
+            throw new FileNotFoundException("No LAS/LAZ point-cloud files were found.");
+        if (metadataCellSizeMeters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(metadataCellSizeMeters));
+
+        var minX = double.PositiveInfinity;
+        var minY = double.PositiveInfinity;
+        var minZ = double.PositiveInfinity;
+        var maxX = double.NegativeInfinity;
+        var maxY = double.NegativeInfinity;
+        var maxZ = double.NegativeInfinity;
+        ulong pointCount = 0;
+        var tileBounds = new List<TileBoundsInfo>(paths.Length);
+
+        foreach (var path in paths)
+        {
+            using var reader = new LasZipNativeReader();
+            reader.Open(path);
+            var h = reader.Header;
+
+            minX = Math.Min(minX, h.MinX);
+            minY = Math.Min(minY, h.MinY);
+            minZ = Math.Min(minZ, h.MinZ);
+            maxX = Math.Max(maxX, h.MaxX);
+            maxY = Math.Max(maxY, h.MaxY);
+            maxZ = Math.Max(maxZ, h.MaxZ);
+            pointCount += reader.PointCount;
+
+            tileBounds.Add(new TileBoundsInfo
+            {
+                FilePath = path,
+                MinX = h.MinX,
+                MinY = h.MinY,
+                MaxX = h.MaxX,
+                MaxY = h.MaxY
+            });
+        }
+
+        var detectedEpsg = epsgCode > 0 ? epsgCode : DetectCommonEpsg(paths);
+        var (projectionWkt, projectionName, linearUnitToMeters) = BuildProjection(detectedEpsg);
+        var nativeBounds = new GeoBoundingBox(minX, minY, maxX, maxY);
+        var wgs84Bounds = projectionWkt == null
+            ? null
+            : GeoBoundingBox.TransformToWgs84(nativeBounds, projectionWkt);
+
+        var nativeCellSize = metadataCellSizeMeters / linearUnitToMeters;
+        var previewWidth = ClampDimension(Math.Ceiling((maxX - minX) / nativeCellSize));
+        var previewHeight = ClampDimension(Math.Ceiling((maxY - minY) / nativeCellSize));
+
+        return new PointCloudInfo
+        {
+            FilePaths = paths,
+            NativeBoundingBox = nativeBounds,
+            Wgs84BoundingBox = wgs84Bounds,
+            TileBounds = tileBounds,
+            ProjectionWkt = projectionWkt,
+            ProjectionName = projectionName,
+            EpsgCode = detectedEpsg,
+            LinearUnitToMeters = linearUnitToMeters,
+            PointCount = pointCount,
+            HeaderMinElevationMeters = minZ * linearUnitToMeters,
+            HeaderMaxElevationMeters = maxZ * linearUnitToMeters,
+            PreviewWidth = previewWidth,
+            PreviewHeight = previewHeight,
+            GeoTransform = [minX, nativeCellSize, 0, maxY, 0, -nativeCellSize]
+        };
+    }
+
+    public GeoTiffImportResult CreateGroundDtm(
+        string[] filePaths,
+        int epsgCode,
+        int targetSize,
+        float metersPerPixel,
+        byte groundClassification = 2,
+        bool crop = false,
+        int cropOffsetX = 0,
+        int cropOffsetY = 0,
+        float metadataCellSizeMeters = DefaultMetadataCellSizeMeters,
+        Action<string>? progress = null)
+    {
+        if (targetSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(targetSize));
+        if (metersPerPixel <= 0)
+            throw new ArgumentOutOfRangeException(nameof(metersPerPixel));
+        if (epsgCode <= 0)
+            throw new ArgumentException("A valid EPSG code is required for LAS/LAZ data.", nameof(epsgCode));
+
+        var info = ReadInfo(filePaths, epsgCode, metadataCellSizeMeters);
+        var outputExtentNative = targetSize * (double)metersPerPixel / info.LinearUnitToMeters;
+        var metadataCellNative = metadataCellSizeMeters / info.LinearUnitToMeters;
+
+        double outputMinX;
+        double outputMaxY;
+        if (crop)
+        {
+            outputMinX = info.NativeBoundingBox.MinLongitude + cropOffsetX * metadataCellNative;
+            outputMaxY = info.NativeBoundingBox.MaxLatitude - cropOffsetY * metadataCellNative;
+        }
+        else
+        {
+            outputMinX = info.NativeBoundingBox.Center.Longitude - outputExtentNative / 2.0;
+            outputMaxY = info.NativeBoundingBox.Center.Latitude + outputExtentNative / 2.0;
+        }
+
+        var outputMaxX = outputMinX + outputExtentNative;
+        var outputMinY = outputMaxY - outputExtentNative;
+        var selectedFiles = info.TileBounds
+            .Where(t => Intersects(t, outputMinX, outputMinY, outputMaxX, outputMaxY))
+            .Select(t => t.FilePath)
+            .ToArray();
+
+        if (selectedFiles.Length == 0)
+            throw new InvalidOperationException("The selected terrain square does not intersect any LAS/LAZ tile.");
+
+        progress?.Invoke($"Scanning ground-class points in {selectedFiles.Length} LAS/LAZ tile(s)...");
+        var groundStats = ScanGroundRange(
+            selectedFiles, groundClassification,
+            outputMinX, outputMinY, outputMaxX, outputMaxY,
+            info.LinearUnitToMeters, progress);
+
+        if (groundStats.Count == 0)
+            throw new InvalidOperationException(
+                $"No classification {groundClassification} points were found in the selected area. " +
+                "Use a classified point cloud with ASPRS class 2 ground points, or correct the crop/CRS.");
+
+        var range = groundStats.MaxElevationMeters - groundStats.MinElevationMeters;
+        if (range <= 0.000001)
+            range = 1.0;
+
+        var cellArea = metersPerPixel * (double)metersPerPixel;
+        var selectedArea = targetSize * (double)targetSize * cellArea;
+        var groundDensity = groundStats.Count / selectedArea;
+        var averageSpacing = groundDensity > 0 ? Math.Sqrt(1.0 / groundDensity) : double.PositiveInfinity;
+        progress?.Invoke(
+            $"Ground scan: {groundStats.Count:N0} points, {groundDensity:F2} pts/m², " +
+            $"average spacing ~{averageSpacing:F2}m, elevation {groundStats.MinElevationMeters:F2}-{groundStats.MaxElevationMeters:F2}m");
+
+        if (metersPerPixel < averageSpacing * 0.75)
+            progress?.Invoke(
+                $"Warning: {metersPerPixel:F2}m cells are finer than the ~{averageSpacing:F2}m average ground-point spacing; " +
+                "empty cells will be interpolated and do not add measured detail.");
+
+        var length = checked(targetSize * targetSize);
+        var samples = GC.AllocateUninitializedArray<ushort>(length);
+        Array.Fill(samples, ushort.MaxValue);
+        var populated = new BitArray(length);
+
+        try
+        {
+            RasterizeGroundPoints(
+                selectedFiles, groundClassification,
+                outputMinX, outputMaxY, outputExtentNative / targetSize,
+                targetSize, groundStats.MinElevationMeters, range,
+                info.LinearUnitToMeters, samples, populated, progress);
+
+            progress?.Invoke("Interpolating cells between measured ground points...");
+            FillMissingCells(samples, populated, targetSize);
+
+            progress?.Invoke("Building 16-bit ground DTM heightmap...");
+            var image = new Image<L16>(targetSize, targetSize);
+            image.ProcessPixelRows(accessor =>
+            {
+                for (var y = 0; y < targetSize; y++)
+                {
+                    var row = accessor.GetRowSpan(y);
+                    var offset = y * targetSize;
+                    for (var x = 0; x < targetSize; x++)
+                        row[x] = new L16(samples[offset + x]);
+                }
+            });
+
+            var selectedNativeBounds = new GeoBoundingBox(outputMinX, outputMinY, outputMaxX, outputMaxY);
+            return new GeoTiffImportResult
+            {
+                HeightmapImage = image,
+                BoundingBox = selectedNativeBounds,
+                Wgs84BoundingBox = info.ProjectionWkt == null
+                    ? null
+                    : GeoBoundingBox.TransformToWgs84(selectedNativeBounds, info.ProjectionWkt),
+                MinElevation = groundStats.MinElevationMeters,
+                MaxElevation = groundStats.MaxElevationMeters,
+                PixelSizeX = metersPerPixel,
+                PixelSizeY = metersPerPixel,
+                Projection = info.ProjectionWkt,
+                SourcePath = selectedFiles.Length == 1 ? selectedFiles[0] : Path.GetDirectoryName(selectedFiles[0])
+            };
+        }
+        finally
+        {
+            samples = null!;
+            populated = null!;
+            // Large 8K/16K working grids should not stay alive into terrain assembly.
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: false);
+        }
+    }
+
+    internal static void FillMissingCells(ushort[] samples, BitArray populated, int size)
+    {
+        var rowHasData = new bool[size];
+
+        // Interpolate gaps horizontally. Dense LiDAR gaps are usually only a few cells;
+        // the same method also bridges water/no-return strips without creating zero trenches.
+        for (var y = 0; y < size; y++)
+        {
+            var rowStart = y * size;
+            var first = -1;
+            for (var x = 0; x < size; x++)
+            {
+                if (!populated[rowStart + x])
+                    continue;
+                first = x;
+                break;
+            }
+
+            if (first < 0)
+                continue;
+
+            rowHasData[y] = true;
+            var firstValue = samples[rowStart + first];
+            for (var x = 0; x < first; x++)
+                samples[rowStart + x] = firstValue;
+
+            var previous = first;
+            for (var x = first + 1; x < size; x++)
+            {
+                if (!populated[rowStart + x])
+                    continue;
+
+                var leftValue = samples[rowStart + previous];
+                var rightValue = samples[rowStart + x];
+                var gap = x - previous;
+                for (var fillX = previous + 1; fillX < x; fillX++)
+                {
+                    var fraction = (fillX - previous) / (double)gap;
+                    samples[rowStart + fillX] = (ushort)Math.Clamp(
+                        Math.Round(leftValue + (rightValue - leftValue) * fraction), 0, ushort.MaxValue);
+                }
+
+                previous = x;
+            }
+
+            var lastValue = samples[rowStart + previous];
+            for (var x = previous + 1; x < size; x++)
+                samples[rowStart + x] = lastValue;
+        }
+
+        var firstDataRow = Array.FindIndex(rowHasData, hasData => hasData);
+        if (firstDataRow < 0)
+            throw new InvalidOperationException("The point cloud did not populate any terrain cells.");
+
+        // Extend the first/last measured row to the output edge.
+        for (var y = 0; y < firstDataRow; y++)
+            Array.Copy(samples, firstDataRow * size, samples, y * size, size);
+
+        var previousRow = firstDataRow;
+        for (var y = firstDataRow + 1; y < size; y++)
+        {
+            if (!rowHasData[y])
+                continue;
+
+            var gap = y - previousRow;
+            for (var fillY = previousRow + 1; fillY < y; fillY++)
+            {
+                var fraction = (fillY - previousRow) / (double)gap;
+                var targetOffset = fillY * size;
+                var topOffset = previousRow * size;
+                var bottomOffset = y * size;
+                for (var x = 0; x < size; x++)
+                {
+                    var top = samples[topOffset + x];
+                    var bottom = samples[bottomOffset + x];
+                    samples[targetOffset + x] = (ushort)Math.Clamp(
+                        Math.Round(top + (bottom - top) * fraction), 0, ushort.MaxValue);
+                }
+            }
+
+            previousRow = y;
+        }
+
+        for (var y = previousRow + 1; y < size; y++)
+            Array.Copy(samples, previousRow * size, samples, y * size, size);
+    }
+
+    private static GroundStats ScanGroundRange(
+        string[] paths,
+        byte groundClass,
+        double minX,
+        double minY,
+        double maxX,
+        double maxY,
+        double unitToMeters,
+        Action<string>? progress)
+    {
+        long count = 0;
+        var minElevation = double.PositiveInfinity;
+        var maxElevation = double.NegativeInfinity;
+
+        for (var fileIndex = 0; fileIndex < paths.Length; fileIndex++)
+        {
+            var path = paths[fileIndex];
+            progress?.Invoke($"Ground scan {fileIndex + 1}/{paths.Length}: {Path.GetFileName(path)}");
+            using var reader = new LasZipNativeReader();
+            reader.Open(path);
+
+            var pointCount = reader.PointCount;
+            for (ulong i = 0; i < pointCount; i++)
+            {
+                if (!reader.ReadPoint(out var x, out var y, out var z, out var classification))
+                    break;
+                if (classification != groundClass || x < minX || x >= maxX || y < minY || y >= maxY)
+                    continue;
+
+                var elevationMeters = z * unitToMeters;
+                minElevation = Math.Min(minElevation, elevationMeters);
+                maxElevation = Math.Max(maxElevation, elevationMeters);
+                count++;
+            }
+        }
+
+        return new GroundStats(count, minElevation, maxElevation);
+    }
+
+    private static void RasterizeGroundPoints(
+        string[] paths,
+        byte groundClass,
+        double minX,
+        double maxY,
+        double nativeCellSize,
+        int size,
+        double minElevationMeters,
+        double elevationRangeMeters,
+        double unitToMeters,
+        ushort[] samples,
+        BitArray populated,
+        Action<string>? progress)
+    {
+        for (var fileIndex = 0; fileIndex < paths.Length; fileIndex++)
+        {
+            var path = paths[fileIndex];
+            progress?.Invoke($"Rasterizing {fileIndex + 1}/{paths.Length}: {Path.GetFileName(path)}");
+            using var reader = new LasZipNativeReader();
+            reader.Open(path);
+
+            var pointCount = reader.PointCount;
+            for (ulong i = 0; i < pointCount; i++)
+            {
+                if (!reader.ReadPoint(out var x, out var y, out var z, out var classification))
+                    break;
+                if (classification != groundClass)
+                    continue;
+
+                var column = (int)Math.Floor((x - minX) / nativeCellSize);
+                var row = (int)Math.Floor((maxY - y) / nativeCellSize);
+                if ((uint)column >= (uint)size || (uint)row >= (uint)size)
+                    continue;
+
+                var normalized = ((z * unitToMeters) - minElevationMeters) / elevationRangeMeters;
+                var packed = (ushort)Math.Clamp(Math.Round(normalized * ushort.MaxValue), 0, ushort.MaxValue);
+                var index = row * size + column;
+
+                // Lowest ground return per cell preserves small drainage cuts and avoids averaging them away.
+                if (!populated[index] || packed < samples[index])
+                {
+                    samples[index] = packed;
+                    populated[index] = true;
+                }
+            }
+        }
+    }
+
+    private static int? DetectCommonEpsg(IEnumerable<string> paths)
+    {
+        int? detected = null;
+        foreach (var path in paths)
+        {
+            var current = LasProjectionReader.TryReadEpsg(path);
+            if (!current.HasValue)
+                continue;
+            if (detected.HasValue && detected.Value != current.Value)
+                return null;
+            detected = current;
+        }
+
+        return detected;
+    }
+
+    private static (string? Wkt, string? Name, double LinearUnitToMeters) BuildProjection(int? epsgCode)
+    {
+        if (!epsgCode.HasValue || epsgCode.Value <= 0)
+            return (null, null, 1.0);
+
+        GeoTiffReader.InitializeGdal();
+        var srs = new SpatialReference(null);
+        if (srs.ImportFromEPSG(epsgCode.Value) != 0)
+            throw new ArgumentException($"Invalid or unsupported EPSG code: {epsgCode.Value}");
+        if (srs.IsProjected() == 0)
+            throw new ArgumentException(
+                $"EPSG:{epsgCode.Value} is geographic (latitude/longitude). LAS/LAZ DTM generation requires a projected CRS in linear units.");
+
+        srs.SetAxisMappingStrategy(AxisMappingStrategy.OAMS_TRADITIONAL_GIS_ORDER);
+        var unitToMeters = srs.GetLinearUnits();
+        if (!double.IsFinite(unitToMeters) || unitToMeters <= 0)
+            unitToMeters = 1.0;
+
+        srs.ExportToWkt(out var wkt, null);
+        return (wkt, srs.GetName(), unitToMeters);
+    }
+
+    private static bool Intersects(
+        TileBoundsInfo tile, double minX, double minY, double maxX, double maxY) =>
+        tile.MaxX > minX && tile.MinX < maxX && tile.MaxY > minY && tile.MinY < maxY;
+
+    private static int ClampDimension(double value) =>
+        (int)Math.Clamp(value, 1, int.MaxValue);
+
+    private readonly record struct GroundStats(long Count, double MinElevationMeters, double MaxElevationMeters);
+}

--- a/BeamNgTerrainPoc/Terrain/Lidar/UsgsLidarDownloadService.cs
+++ b/BeamNgTerrainPoc/Terrain/Lidar/UsgsLidarDownloadService.cs
@@ -1,0 +1,560 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using BeamNgTerrainPoc.Terrain.GeoTiff;
+
+namespace BeamNgTerrainPoc.Terrain.Lidar;
+
+/// <summary>
+/// Searches The National Map for USGS 3DEP Lidar Point Cloud products and
+/// downloads classified LAZ tiles into a persistent, resumable cache.
+/// </summary>
+public sealed class UsgsLidarDownloadService : IDisposable
+{
+    public const string ProductsEndpoint = "https://tnmaccess.nationalmap.gov/api/v1/products";
+    public const int MaximumSearchProducts = 5000;
+
+    // TNMAccess takes roughly 20 seconds to build a 100-product LPC page for
+    // dense areas. Asking for 1,000 products regularly exceeds its gateway
+    // timeout even though the same query succeeds when paged more conservatively.
+    private const int PageSize = 100;
+    private const int MaximumRetries = 4;
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    public UsgsLidarDownloadService(HttpClient? httpClient = null) :
+        this(httpClient, Task.Delay)
+    {
+    }
+
+    internal UsgsLidarDownloadService(
+        HttpClient? httpClient,
+        Func<TimeSpan, CancellationToken, Task> delayAsync)
+    {
+        _ownsHttpClient = httpClient == null;
+        _httpClient = httpClient ?? new HttpClient { Timeout = TimeSpan.FromMinutes(60) };
+        _delayAsync = delayAsync ?? throw new ArgumentNullException(nameof(delayAsync));
+    }
+
+    public async Task<UsgsLidarSearchResult> SearchAsync(
+        GeoBoundingBox bounds,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateBounds(bounds);
+        var products = new Dictionary<string, UsgsLidarProduct>(StringComparer.OrdinalIgnoreCase);
+        var totalAvailable = 0;
+        var offset = 0;
+
+        while (offset < MaximumSearchProducts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            progress?.Report(offset == 0
+                ? "Searching USGS 3DEP classified LAZ tiles..."
+                : $"Reading USGS results {offset + 1:N0} and later...");
+
+            var page = await FetchSearchPageWithRetryAsync(bounds, offset, progress, cancellationToken);
+            totalAvailable = Math.Max(totalAvailable, page.TotalAvailable);
+
+            foreach (var product in page.Products)
+            {
+                var key = !string.IsNullOrWhiteSpace(product.SourceId)
+                    ? product.SourceId
+                    : product.DownloadUri.AbsoluteUri;
+                products.TryAdd(key, product);
+            }
+
+            if (page.RawItemCount == 0 || offset + page.RawItemCount >= totalAvailable)
+                break;
+
+            offset += page.RawItemCount;
+        }
+
+        var ordered = products.Values
+            .OrderBy(product => product.Title, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(product => product.DownloadUri.AbsoluteUri, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return new UsgsLidarSearchResult(
+            totalAvailable,
+            ordered,
+            totalAvailable > MaximumSearchProducts);
+    }
+
+    public static GeoBoundingBox BuildSquareBounds(
+        double centerLatitude,
+        double centerLongitude,
+        double sideMeters)
+    {
+        if (centerLatitude is < -85 or > 85)
+            throw new ArgumentOutOfRangeException(nameof(centerLatitude));
+        if (centerLongitude is < -180 or > 180)
+            throw new ArgumentOutOfRangeException(nameof(centerLongitude));
+        if (!double.IsFinite(sideMeters) || sideMeters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(sideMeters));
+
+        const double metersPerDegreeLatitude = 111_320.0;
+        var halfSide = sideMeters / 2.0;
+        var latitudeDelta = halfSide / metersPerDegreeLatitude;
+        var longitudeScale = metersPerDegreeLatitude * Math.Cos(centerLatitude * Math.PI / 180.0);
+        var longitudeDelta = halfSide / longitudeScale;
+
+        return new GeoBoundingBox(
+            centerLongitude - longitudeDelta,
+            centerLatitude - latitudeDelta,
+            centerLongitude + longitudeDelta,
+            centerLatitude + latitudeDelta);
+    }
+
+    private async Task<UsgsLidarSearchPage> FetchSearchPageWithRetryAsync(
+        GeoBoundingBox bounds,
+        int offset,
+        IProgress<string>? progress,
+        CancellationToken cancellationToken)
+    {
+        Exception? lastError = null;
+        HttpStatusCode? lastStatusCode = null;
+
+        for (var attempt = 1; attempt <= MaximumRetries; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TimeSpan? serverRetryDelay = null;
+
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, BuildSearchUri(bounds, PageSize, offset));
+                request.Headers.UserAgent.Add(new ProductInfoHeaderValue("BeamNG-LevelCleanUp", "1.0"));
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var json = await response.Content.ReadAsStringAsync(cancellationToken);
+                    return ParseSearchResponse(json, bounds);
+                }
+
+                lastStatusCode = response.StatusCode;
+                if (!IsTransientStatus(response.StatusCode))
+                    response.EnsureSuccessStatusCode();
+
+                lastError = new HttpRequestException(
+                    $"USGS returned {(int)response.StatusCode} ({response.ReasonPhrase}).",
+                    null,
+                    response.StatusCode);
+                serverRetryDelay = GetRetryDelay(response, attempt);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (TaskCanceledException ex)
+            {
+                lastError = new TimeoutException("The USGS catalog request timed out.", ex);
+                lastStatusCode = null;
+            }
+            catch (UsgsLidarCatalogException ex)
+            {
+                // TNMAccess sometimes returns HTTP 200 with an error payload while
+                // its ScienceBase inventory is busy. Treat that as transient too.
+                lastError = ex;
+                lastStatusCode = null;
+            }
+            catch (HttpRequestException ex) when (!ex.StatusCode.HasValue || IsTransientStatus(ex.StatusCode.Value))
+            {
+                lastError = ex;
+                lastStatusCode = ex.StatusCode;
+            }
+
+            if (attempt >= MaximumRetries)
+                break;
+
+            var reason = lastStatusCode.HasValue
+                ? $"{(int)lastStatusCode.Value} {lastStatusCode.Value}"
+                : lastError?.Message ?? "a temporary error";
+            progress?.Report(
+                $"USGS catalog returned {reason}. Retrying results {offset + 1:N0}+ " +
+                $"({attempt + 1}/{MaximumRetries})...");
+            await _delayAsync(serverRetryDelay ?? GetRetryDelay(null, attempt), cancellationToken);
+        }
+
+        throw new HttpRequestException(
+            $"The USGS catalog stayed unavailable after {MaximumRetries} attempts. " +
+            "No LAZ files were downloaded; retry the search in a few minutes.",
+            lastError,
+            lastStatusCode);
+    }
+
+    public async Task<UsgsLidarDownloadResult> DownloadAsync(
+        IEnumerable<UsgsLidarProduct> products,
+        string cacheRoot,
+        IProgress<UsgsLidarDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(cacheRoot))
+            throw new ArgumentException("A cache directory is required.", nameof(cacheRoot));
+
+        var selected = products
+            .GroupBy(product => product.DownloadUri.AbsoluteUri, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
+        if (selected.Count == 0)
+            throw new InvalidOperationException("Select at least one USGS LAZ tile.");
+
+        Directory.CreateDirectory(cacheRoot);
+        var downloaded = 0;
+        var reused = 0;
+        var paths = new List<string>(selected.Count);
+
+        for (var index = 0; index < selected.Count; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var product = selected[index];
+            var destinationPath = Path.Combine(cacheRoot, GetCacheFileName(product));
+
+            if (IsValidLasFile(destinationPath, product.SizeInBytes))
+            {
+                reused++;
+                paths.Add(destinationPath);
+                progress?.Report(new UsgsLidarDownloadProgress(
+                    index + 1, selected.Count, reused, downloaded,
+                    $"Reused cached USGS LAZ tile {index + 1:N0}/{selected.Count:N0}"));
+                continue;
+            }
+
+            await DownloadProductAsync(product, destinationPath, cancellationToken);
+            downloaded++;
+            paths.Add(destinationPath);
+            progress?.Report(new UsgsLidarDownloadProgress(
+                index + 1, selected.Count, reused, downloaded,
+                $"Downloaded USGS LAZ tile {index + 1:N0}/{selected.Count:N0}"));
+        }
+
+        return new UsgsLidarDownloadResult(paths, reused, downloaded);
+    }
+
+    internal static Uri BuildSearchUri(GeoBoundingBox bounds, int maximum, int offset)
+    {
+        ValidateBounds(bounds);
+        if (maximum is < 1 or > PageSize)
+            throw new ArgumentOutOfRangeException(nameof(maximum));
+        if (offset < 0)
+            throw new ArgumentOutOfRangeException(nameof(offset));
+
+        var bbox = string.Join(",",
+            Format(bounds.MinLongitude),
+            Format(bounds.MinLatitude),
+            Format(bounds.MaxLongitude),
+            Format(bounds.MaxLatitude));
+        var query = string.Join("&",
+            $"bbox={Uri.EscapeDataString(bbox)}",
+            $"datasets={Uri.EscapeDataString("Lidar Point Cloud (LPC)")}",
+            $"prodFormats={Uri.EscapeDataString("LAS,LAZ")}",
+            "outputFormat=JSON",
+            $"max={maximum}",
+            $"offset={offset}");
+        return new Uri($"{ProductsEndpoint}?{query}");
+    }
+
+    internal static UsgsLidarSearchPage ParseSearchResponse(string json, GeoBoundingBox requestedBounds)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        if (root.TryGetProperty("error", out var errorElement) &&
+            errorElement.ValueKind == JsonValueKind.String)
+        {
+            var message = errorElement.GetString();
+            throw new UsgsLidarCatalogException(
+                string.IsNullOrWhiteSpace(message)
+                    ? "The USGS catalog returned an error response."
+                    : $"The USGS catalog returned an error: {message}");
+        }
+
+        var total = root.TryGetProperty("total", out var totalElement) && totalElement.TryGetInt32(out var parsedTotal)
+            ? parsedTotal
+            : 0;
+        if (!root.TryGetProperty("items", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            if (total > 0)
+                throw new UsgsLidarCatalogException("The USGS catalog response did not include its product list.");
+            return new UsgsLidarSearchPage(total, 0, Array.Empty<UsgsLidarProduct>());
+        }
+
+        var products = new List<UsgsLidarProduct>();
+        foreach (var item in items.EnumerateArray())
+        {
+            var downloadUrl = FirstString(item, "downloadLazURL", "downloadURL");
+            if (string.IsNullOrWhiteSpace(downloadUrl) &&
+                item.TryGetProperty("urls", out var urls) && urls.ValueKind == JsonValueKind.Object)
+                downloadUrl = FirstString(urls, "LAZ", "LAS");
+            if (!Uri.TryCreate(downloadUrl, UriKind.Absolute, out var downloadUri) ||
+                downloadUri.Scheme != Uri.UriSchemeHttps)
+                continue;
+
+            if (!TryReadBounds(item, out var productBounds) || !Intersects(requestedBounds, productBounds))
+                continue;
+
+            products.Add(new UsgsLidarProduct(
+                FirstString(item, "sourceId") ?? string.Empty,
+                FirstString(item, "title") ?? Path.GetFileName(downloadUri.LocalPath),
+                downloadUri,
+                TryReadInt64(item, "sizeInBytes"),
+                productBounds,
+                FirstString(item, "publicationDate", "lastUpdated")));
+        }
+
+        return new UsgsLidarSearchPage(total, items.GetArrayLength(), products);
+    }
+
+    private async Task DownloadProductAsync(
+        UsgsLidarProduct product,
+        string destinationPath,
+        CancellationToken cancellationToken)
+    {
+        var partialPath = destinationPath + ".partial";
+        if (File.Exists(destinationPath) && !IsValidLasFile(destinationPath, product.SizeInBytes))
+            File.Delete(destinationPath);
+
+        for (var attempt = 1; attempt <= MaximumRetries; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var existingLength = File.Exists(partialPath) ? new FileInfo(partialPath).Length : 0;
+                using var request = new HttpRequestMessage(HttpMethod.Get, product.DownloadUri);
+                request.Headers.UserAgent.Add(new ProductInfoHeaderValue("BeamNG-LevelCleanUp", "1.0"));
+                if (existingLength > 0)
+                    request.Headers.Range = new RangeHeaderValue(existingLength, null);
+
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+
+                if (response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable &&
+                    IsValidLasFile(partialPath, product.SizeInBytes))
+                {
+                    File.Move(partialPath, destinationPath, true);
+                    return;
+                }
+
+                if (response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+                {
+                    // A stale/oversized partial cannot be resumed. Restart it rather than
+                    // permanently trapping every future attempt at HTTP 416.
+                    if (File.Exists(partialPath)) File.Delete(partialPath);
+                    if (attempt < MaximumRetries) continue;
+                }
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var append = existingLength > 0 && response.StatusCode == HttpStatusCode.PartialContent;
+                    if (append && response.Content.Headers.ContentRange?.From is { } rangeStart &&
+                        rangeStart != existingLength)
+                    {
+                        if (File.Exists(partialPath)) File.Delete(partialPath);
+                        if (attempt < MaximumRetries) continue;
+                        throw new InvalidDataException(
+                            $"USGS returned an invalid resume range for '{product.Title}'.");
+                    }
+
+                    await using var source = await response.Content.ReadAsStreamAsync(cancellationToken);
+                    await using (var destination = new FileStream(
+                                     partialPath,
+                                     append ? FileMode.Append : FileMode.Create,
+                                     FileAccess.Write,
+                                     FileShare.None,
+                                     1024 * 1024,
+                                     FileOptions.Asynchronous | FileOptions.SequentialScan))
+                    {
+                        await source.CopyToAsync(destination, 1024 * 1024, cancellationToken);
+                    }
+
+                    if (!IsValidLasFile(partialPath, product.SizeInBytes))
+                    {
+                        if (attempt < MaximumRetries)
+                        {
+                            await _delayAsync(GetRetryDelay(response, attempt), cancellationToken);
+                            continue;
+                        }
+
+                        throw new InvalidDataException(
+                            $"USGS returned an incomplete or invalid LAS/LAZ file for '{product.Title}'.");
+                    }
+
+                    File.Move(partialPath, destinationPath, true);
+                    return;
+                }
+
+                if (IsTransientStatus(response.StatusCode) && attempt < MaximumRetries)
+                {
+                    await _delayAsync(GetRetryDelay(response, attempt), cancellationToken);
+                    continue;
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (TaskCanceledException) when (attempt < MaximumRetries)
+            {
+                await _delayAsync(GetRetryDelay(null, attempt), cancellationToken);
+            }
+            catch (HttpRequestException ex) when (
+                attempt < MaximumRetries &&
+                (!ex.StatusCode.HasValue || IsTransientStatus(ex.StatusCode.Value)))
+            {
+                await _delayAsync(GetRetryDelay(null, attempt), cancellationToken);
+            }
+            catch (HttpIOException) when (attempt < MaximumRetries)
+            {
+                // The partial file remains on disk and the next request resumes it.
+                await _delayAsync(GetRetryDelay(null, attempt), cancellationToken);
+            }
+        }
+    }
+
+    private static bool IsTransientStatus(HttpStatusCode statusCode) =>
+        statusCode == HttpStatusCode.RequestTimeout ||
+        statusCode == HttpStatusCode.TooManyRequests ||
+        (int)statusCode >= 500;
+
+    private static TimeSpan GetRetryDelay(HttpResponseMessage? response, int attempt)
+    {
+        if (response?.Headers.RetryAfter?.Delta is { } delta)
+            return delta;
+        return TimeSpan.FromSeconds(Math.Min(30, Math.Pow(2, attempt)));
+    }
+
+    private static string GetCacheFileName(UsgsLidarProduct product)
+    {
+        var fileName = Uri.UnescapeDataString(Path.GetFileName(product.DownloadUri.LocalPath));
+        if (string.IsNullOrWhiteSpace(fileName))
+            fileName = string.IsNullOrWhiteSpace(product.SourceId) ? "usgs_3dep.laz" : $"{product.SourceId}.laz";
+
+        var invalid = Path.GetInvalidFileNameChars();
+        fileName = new string(fileName.Select(character => invalid.Contains(character) ? '_' : character).ToArray());
+        var extension = Path.GetExtension(fileName);
+        if (!extension.Equals(".laz", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".las", StringComparison.OrdinalIgnoreCase))
+            extension = ".laz";
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        if (stem.Length > 120)
+            stem = stem[..120];
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(product.DownloadUri.AbsoluteUri)))[..10]
+            .ToLowerInvariant();
+        return $"{stem}_{hash}{extension}";
+    }
+
+    private static bool IsValidLasFile(string path, long expectedSize)
+    {
+        try
+        {
+            var info = new FileInfo(path);
+            if (!info.Exists || info.Length < 227 || expectedSize > 0 && info.Length != expectedSize)
+                return false;
+            Span<byte> signature = stackalloc byte[4];
+            using var stream = info.OpenRead();
+            return stream.Read(signature) == 4 && signature.SequenceEqual("LASF"u8);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool TryReadBounds(JsonElement item, out GeoBoundingBox bounds)
+    {
+        bounds = null!;
+        if (!item.TryGetProperty("boundingBox", out var bbox) || bbox.ValueKind != JsonValueKind.Object ||
+            !TryReadDouble(bbox, "minX", out var minX) || !TryReadDouble(bbox, "minY", out var minY) ||
+            !TryReadDouble(bbox, "maxX", out var maxX) || !TryReadDouble(bbox, "maxY", out var maxY))
+            return false;
+        bounds = new GeoBoundingBox(minX, minY, maxX, maxY);
+        return bounds.IsValidWgs84 && bounds.Width > 0 && bounds.Height > 0;
+    }
+
+    private static string? FirstString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+            if (element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String &&
+                !string.IsNullOrWhiteSpace(value.GetString()))
+                return value.GetString();
+        return null;
+    }
+
+    private static long TryReadInt64(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value)) return 0;
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out var number)) return number;
+        return value.ValueKind == JsonValueKind.String && long.TryParse(value.GetString(), out number) ? number : 0;
+    }
+
+    private static bool TryReadDouble(JsonElement element, string name, out double value)
+    {
+        value = 0;
+        if (!element.TryGetProperty(name, out var property)) return false;
+        if (property.ValueKind == JsonValueKind.Number) return property.TryGetDouble(out value);
+        return property.ValueKind == JsonValueKind.String &&
+               double.TryParse(property.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool Intersects(GeoBoundingBox left, GeoBoundingBox right) =>
+        left.MinLongitude <= right.MaxLongitude && left.MaxLongitude >= right.MinLongitude &&
+        left.MinLatitude <= right.MaxLatitude && left.MaxLatitude >= right.MinLatitude;
+
+    private static void ValidateBounds(GeoBoundingBox bounds)
+    {
+        if (bounds is not { IsValidWgs84: true } || bounds.Width <= 0 || bounds.Height <= 0)
+            throw new ArgumentException("Valid WGS84 map bounds are required.", nameof(bounds));
+    }
+
+    private static string Format(double value) => value.ToString("0.########", CultureInfo.InvariantCulture);
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient)
+            _httpClient.Dispose();
+    }
+}
+
+public sealed record UsgsLidarProduct(
+    string SourceId,
+    string Title,
+    Uri DownloadUri,
+    long SizeInBytes,
+    GeoBoundingBox Bounds,
+    string? PublicationDate);
+
+public sealed record UsgsLidarSearchResult(
+    int TotalAvailable,
+    IReadOnlyList<UsgsLidarProduct> Products,
+    bool WasTruncated)
+{
+    public long TotalSizeInBytes => Products.Sum(product => Math.Max(0, product.SizeInBytes));
+}
+
+internal sealed record UsgsLidarSearchPage(
+    int TotalAvailable,
+    int RawItemCount,
+    IReadOnlyList<UsgsLidarProduct> Products);
+
+internal sealed class UsgsLidarCatalogException(string message) : Exception(message);
+
+public sealed record UsgsLidarDownloadProgress(
+    int CompletedFiles,
+    int TotalFiles,
+    int ReusedFiles,
+    int DownloadedFiles,
+    string Message);
+
+public sealed record UsgsLidarDownloadResult(
+    IReadOnlyList<string> FilePaths,
+    int ReusedFiles,
+    int DownloadedFiles);

--- a/BeamNgTerrainPoc/Terrain/Models/TerrainCreationParameters.cs
+++ b/BeamNgTerrainPoc/Terrain/Models/TerrainCreationParameters.cs
@@ -122,6 +122,34 @@ public class TerrainCreationParameters
     public int XyzEpsgCode { get; set; } = 25832;
 
     /// <summary>
+    ///     Paths to classified LAS/LAZ point-cloud tiles. Only points matching
+    ///     <see cref="LidarGroundClassification"/> are rasterized into the DTM.
+    /// </summary>
+    public string[]? LidarFilePaths { get; set; }
+
+    /// <summary>
+    ///     EPSG code for the LAS/LAZ horizontal coordinate reference system.
+    ///     LAS/LAZ files do not always carry readable CRS metadata, so the UI lets the user correct it.
+    /// </summary>
+    public int LidarEpsgCode { get; set; }
+
+    /// <summary>
+    ///     ASPRS classification to rasterize. Class 2 is bare-earth ground.
+    /// </summary>
+    public byte LidarGroundClassification { get; set; } = 2;
+
+    /// <summary>
+    ///     Cell size used to describe the point-cloud extent in the crop selector.
+    ///     This is independent of the final terrain square size in <see cref="MetersPerPixel"/>.
+    /// </summary>
+    public float LidarMetadataCellSizeMeters { get; set; } = 0.5f;
+
+    /// <summary>
+    ///     When true, saves the ground-only 16-bit DTM PNG alongside terrain-generation diagnostics.
+    /// </summary>
+    public bool ExportLidarDtmHeightmap { get; set; } = true;
+
+    /// <summary>
     ///     Geographic bounding box of the terrain.
     ///     Automatically populated when importing from GeoTIFF.
     ///     Can be used for OSM Overpass API queries to fetch roads, buildings, etc.

--- a/BeamNgTerrainPoc/Terrain/TerrainCreator.cs
+++ b/BeamNgTerrainPoc/Terrain/TerrainCreator.cs
@@ -4,6 +4,7 @@ using BeamNG.Procedural3D.RoadMesh;
 using BeamNgTerrainPoc.Terrain.Export;
 using BeamNgTerrainPoc.Terrain.GeoTiff;
 using BeamNgTerrainPoc.Terrain.Logging;
+using BeamNgTerrainPoc.Terrain.Lidar;
 using BeamNgTerrainPoc.Terrain.Models;
 using BeamNgTerrainPoc.Terrain.Models.RoadGeometry;
 using BeamNgTerrainPoc.Terrain.Processing;
@@ -141,6 +142,23 @@ public class TerrainCreator
                 isGeoTiffSource = true; // GeoTIFF may have data artifacts
                 perfLog.Timing($"Loaded GeoTIFF directory heightmap: {sw.Elapsed.TotalSeconds:F2}s");
             }
+            else if (parameters.LidarFilePaths is { Length: > 0 })
+            {
+                perfLog.Info($"Creating ground-only DTM from {parameters.LidarFilePaths.Length} LAS/LAZ tile(s)");
+                heightmapImage = await LoadFromLidarAsync(parameters, perfLog);
+                shouldDisposeHeightmap = true;
+                isGeoTiffSource = true;
+                perfLog.Timing($"Created LAS/LAZ ground DTM: {sw.Elapsed.TotalSeconds:F2}s");
+
+                if (parameters.ExportLidarDtmHeightmap)
+                {
+                    Directory.CreateDirectory(debugBaseDir!);
+                    var dtmPath = Path.Combine(
+                        debugBaseDir!, $"{parameters.TerrainName}_lidar_ground_dtm_16bit.png");
+                    perfLog.Info($"Saving ground-only 16-bit DTM: {dtmPath}");
+                    await heightmapImage.SaveAsPngAsync(dtmPath);
+                }
+            }
             else if (parameters.XyzFilePaths is { Length: > 0 })
             {
                 // Combine and load from multiple XYZ ASCII tiles
@@ -164,7 +182,7 @@ public class TerrainCreator
             else
             {
                 perfLog.Error(
-                    "No heightmap provided (HeightmapImage, HeightmapPath, GeoTiffPath, GeoTiffDirectory, or XyzPath required)");
+                    "No heightmap provided (PNG, GeoTIFF, XYZ, or classified LAS/LAZ required)");
                 return false;
             }
 
@@ -899,6 +917,57 @@ public class TerrainCreator
         {
             log.Warning("Could not determine WGS84 bounding box from XYZ - OSM features will not be available.");
         }
+
+        return result.HeightmapImage;
+    }
+
+    /// <summary>
+    ///     Streams classified LAS/LAZ files, keeps ASPRS ground-class points, and rasterizes
+    ///     them directly at the BeamNG terrain square size.
+    /// </summary>
+    private async Task<Image<L16>> LoadFromLidarAsync(
+        TerrainCreationParameters parameters, TerrainCreationLogger log)
+    {
+        var reader = new LidarPointCloudReader();
+        var result = await Task.Run(() => reader.CreateGroundDtm(
+            parameters.LidarFilePaths!,
+            parameters.LidarEpsgCode,
+            parameters.Size,
+            parameters.MetersPerPixel,
+            parameters.LidarGroundClassification,
+            parameters.CropGeoTiff && parameters.CropWidth > 0 && parameters.CropHeight > 0,
+            parameters.CropOffsetX,
+            parameters.CropOffsetY,
+            parameters.LidarMetadataCellSizeMeters,
+            message =>
+            {
+                if (message.StartsWith("Warning:", StringComparison.OrdinalIgnoreCase))
+                    log.Warning(message[8..].Trim());
+                else
+                    log.Info(message);
+            }));
+
+        parameters.GeoBoundingBox = result.Wgs84BoundingBox ??
+                                    (result.BoundingBox.IsValidWgs84 ? result.BoundingBox : null);
+        parameters.GeoTiffMinElevation = result.MinElevation;
+        parameters.GeoTiffMaxElevation = result.MaxElevation;
+
+        if (parameters.MaxHeight <= 0)
+        {
+            parameters.MaxHeight = (float)Math.Max(result.ElevationRange, 0.01);
+            log.Info($"Using ground DTM elevation range as MaxHeight: {parameters.MaxHeight:F2}m");
+        }
+
+        if (parameters.AutoSetBaseHeightFromGeoTiff)
+        {
+            parameters.TerrainBaseHeight = (float)result.MinElevation;
+            log.Info($"Using ground DTM minimum as TerrainBaseHeight: {parameters.TerrainBaseHeight:F2}m");
+        }
+
+        if (parameters.GeoBoundingBox != null)
+            log.Info($"LAS/LAZ DTM bounding box for Overpass API: {parameters.GeoBoundingBox.ToOverpassBBox()}");
+        else
+            log.Warning("Could not transform LAS/LAZ bounds to WGS84; verify the EPSG code.");
 
         return result.HeightmapImage;
     }

--- a/BeamNgTerrainPoc/Terrain/Validation/TerrainValidator.cs
+++ b/BeamNgTerrainPoc/Terrain/Validation/TerrainValidator.cs
@@ -38,11 +38,12 @@ public static class TerrainValidator
             !string.IsNullOrWhiteSpace(parameters.GeoTiffPath) ||
             !string.IsNullOrWhiteSpace(parameters.GeoTiffDirectory) ||
             !string.IsNullOrWhiteSpace(parameters.XyzPath) ||
-            (parameters.XyzFilePaths != null && parameters.XyzFilePaths.Length > 0);
+            (parameters.XyzFilePaths != null && parameters.XyzFilePaths.Length > 0) ||
+            (parameters.LidarFilePaths != null && parameters.LidarFilePaths.Length > 0);
 
         if (!hasHeightmapSource)
         {
-            result.Errors.Add("Heightmap is required (provide HeightmapImage, HeightmapPath, GeoTiffPath, GeoTiffDirectory, or XYZ files)");
+            result.Errors.Add("Heightmap is required (provide PNG, GeoTIFF, XYZ, or classified LAS/LAZ files)");
             result.IsValid = false;
         }
         
@@ -84,6 +85,33 @@ public static class TerrainValidator
                     result.Errors.Add($"XYZ file not found: {xyzFile}");
                     result.IsValid = false;
                 }
+            }
+        }
+
+        if (parameters.LidarFilePaths != null)
+        {
+            foreach (var lidarFile in parameters.LidarFilePaths)
+            {
+                if (string.IsNullOrWhiteSpace(lidarFile) || !File.Exists(lidarFile))
+                {
+                    result.Errors.Add($"LAS/LAZ file not found: {lidarFile}");
+                    result.IsValid = false;
+                    continue;
+                }
+
+                var extension = Path.GetExtension(lidarFile);
+                if (!extension.Equals(".las", StringComparison.OrdinalIgnoreCase) &&
+                    !extension.Equals(".laz", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Errors.Add($"Unsupported point-cloud file type: {lidarFile}");
+                    result.IsValid = false;
+                }
+            }
+
+            if (parameters.LidarFilePaths.Length > 0 && parameters.LidarEpsgCode <= 0)
+            {
+                result.Errors.Add("A valid EPSG code is required for LAS/LAZ terrain generation");
+                result.IsValid = false;
             }
         }
 
@@ -137,7 +165,8 @@ public static class TerrainValidator
         bool isUsingGeoSource = !string.IsNullOrWhiteSpace(parameters.GeoTiffPath) ||
                                 !string.IsNullOrWhiteSpace(parameters.GeoTiffDirectory) ||
                                 !string.IsNullOrWhiteSpace(parameters.XyzPath) ||
-                                (parameters.XyzFilePaths != null && parameters.XyzFilePaths.Length > 0);
+                                (parameters.XyzFilePaths != null && parameters.XyzFilePaths.Length > 0) ||
+                                (parameters.LidarFilePaths != null && parameters.LidarFilePaths.Length > 0);
         if (parameters.MaxHeight <= 0 && !isUsingGeoSource)
         {
             result.Errors.Add("MaxHeight must be positive (or use GeoTIFF/XYZ import which auto-calculates height)");


### PR DESCRIPTION
## Summary
- accept classified LAS and LAZ point-cloud tiles as terrain elevation sources
- find free USGS 3DEP classified point clouds directly in LevelCleanUp and select intersecting LAZ products
- use TNMAccess' current LAS,LAZ format token and conservative pagination to avoid gateway timeouts
- retry transient catalog failures, including 429/5xx responses and TNMAccess HTTP-200 error payloads
- persist completed and partial downloads so cancelled or interrupted LAZ transfers resume without redownloading
- detect embedded projection metadata and allow an EPSG override when the source does not identify its CRS
- filter ground-class points (ASPRS class 2 by default), rasterize the selected crop at a configurable DTM cell size, and interpolate empty cells
- carry the LiDAR settings through terrain presets and optionally save the generated 16-bit ground DTM for diagnostics
- keep source point-cloud files local and unchanged

## Validation
- 346 tests passed, including catalog retry, resumable download, LAS/LAZ parsing, and DTM coverage
- application build completed with 0 errors
- live Weston County smoke test found 6 products, downloaded one 18.9 MB LAZ, reused it from cache, detected EPSG:6350, read 3,304,344 points, rasterized 713,311 class-2 points, and produced a non-empty 256 x 256 16-bit DTM