### PR TITLE
Add a configurable visual terrain backdrop

### DIFF
--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetExporter.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetExporter.razor
@@ -67,6 +67,8 @@
     [Parameter] public int XyzEpsgCode { get; set; }
     [Parameter] public string? CachedCombinedGeoTiffPath { get; set; }
     [Parameter] public bool UpdateTerrainBlock { get; set; } = true;
+    [Parameter] public bool EnableTerrainBackdrop { get; set; }
+    [Parameter] public float TerrainBackdropDistanceMeters { get; set; } = 5000f;
     [Parameter] public bool EnableCrossMaterialHarmonization { get; set; }
     [Parameter] public bool ExcludeBridgesFromTerrain { get; set; } = false;
     [Parameter] public bool ExcludeTunnelsFromTerrain { get; set; } = false;
@@ -465,6 +467,8 @@
                 ["metersPerPixel"] = MetersPerPixel,
                 ["terrainBaseHeight"] = TerrainBaseHeight,
                 ["updateTerrainBlock"] = UpdateTerrainBlock,
+                ["enableTerrainBackdrop"] = EnableTerrainBackdrop,
+                ["terrainBackdropDistanceMeters"] = TerrainBackdropDistanceMeters,
                 ["enableCrossMaterialHarmonization"] = EnableCrossMaterialHarmonization,
                 ["excludeBridgesFromTerrain"] = ExcludeBridgesFromTerrain,
                 ["excludeTunnelsFromTerrain"] = ExcludeTunnelsFromTerrain,

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetImporter.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetImporter.razor
@@ -679,6 +679,10 @@ public List<TerrainMaterialItemExtended> Materials { get; set; } = new();
                     result.TerrainSize = terrainOptions["terrainSize"]!.GetValue<int>();
                 if (terrainOptions["updateTerrainBlock"] != null)
                     result.UpdateTerrainBlock = terrainOptions["updateTerrainBlock"]!.GetValue<bool>();
+                if (terrainOptions["enableTerrainBackdrop"] != null)
+                    result.EnableTerrainBackdrop = terrainOptions["enableTerrainBackdrop"]!.GetValue<bool>();
+                if (terrainOptions["terrainBackdropDistanceMeters"] != null)
+                    result.TerrainBackdropDistanceMeters = terrainOptions["terrainBackdropDistanceMeters"]!.GetValue<float>();
                 if (terrainOptions["enableCrossMaterialHarmonization"] != null)
                     result.EnableCrossMaterialHarmonization = terrainOptions["enableCrossMaterialHarmonization"]!.GetValue<bool>();
                 // Note: globalJunctionDetectionRadiusMeters and globalJunctionBlendDistanceMeters

--- a/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetResult.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Components/TerrainPresetResult.cs
@@ -91,6 +91,16 @@ public class TerrainPresetResult
     public bool? UpdateTerrainBlock { get; set; }
 
     /// <summary>
+    ///     Whether to generate a separate visual terrain backdrop around the TerrainBlock.
+    /// </summary>
+    public bool? EnableTerrainBackdrop { get; set; }
+
+    /// <summary>
+    ///     Visual backdrop distance beyond each playable terrain edge, in meters.
+    /// </summary>
+    public float? TerrainBackdropDistanceMeters { get; set; }
+
+    /// <summary>
     ///     Whether to enable cross-material harmonization for road smoothing.
     /// </summary>
     public bool? EnableCrossMaterialHarmonization { get; set; }

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor
@@ -106,6 +106,8 @@
                                        XyzEpsgCode="@_xyzEpsgCode"
                                        CachedCombinedGeoTiffPath="@_cachedCombinedGeoTiffPath"
                                        UpdateTerrainBlock="@_updateTerrainBlock"
+                                       EnableTerrainBackdrop="@_state.EnableTerrainBackdrop"
+                                       TerrainBackdropDistanceMeters="@_state.TerrainBackdropDistanceMeters"
                                        EnableCrossMaterialHarmonization="@_enableCrossMaterialHarmonization"
                                        ExcludeBridgesFromTerrain="@_excludeBridgesFromTerrain"
                                        ExcludeTunnelsFromTerrain="@_excludeTunnelsFromTerrain"
@@ -480,6 +482,37 @@
                                              Variant="Variant.Outlined"
                                              Min="-10000.0f" Max="10000.0f" Step="1.0f"
                                              HelperText="@(_heightmapSourceType != HeightmapSourceType.Png ? "Auto-calculated from GeoTIFF min elevation" : "Z position offset for terrain")" />
+                        </MudItem>
+
+                        <MudItem xs="12">
+                            <MudDivider Class="my-2" />
+                            <MudText Typo="Typo.subtitle2" Class="mb-2">
+                                <MudIcon Icon="@Icons.Material.Filled.Landscape" Size="Size.Small" Class="mr-1" />
+                                Visual Surrounding Background
+                            </MudText>
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudCheckBox @bind-Value="_state.EnableTerrainBackdrop"
+                                         Label="Generate terrain backdrop"
+                                         Color="Color.Primary" />
+                        </MudItem>
+
+                        <MudItem xs="12" sm="6" md="4">
+                            <MudNumericField T="float"
+                                             @bind-Value="_state.TerrainBackdropDistanceMeters"
+                                             Label="Backdrop Distance (m)"
+                                             Variant="Variant.Outlined"
+                                             Min="250f" Max="100000f" Step="250f"
+                                             Disabled="@(!_state.EnableTerrainBackdrop)"
+                                             HelperText="Distance beyond each playable-terrain edge" />
+                        </MudItem>
+
+                        <MudItem xs="12" md="5">
+                            <MudAlert Severity="Severity.Info" Dense="true">
+                                Creates a separate, non-colliding TSStatic ring. It edge-extends the finished elevation and stretches a
+                                2048px copy of MT_basecolor.png; LevelCleanUp does not paint or overwrite it as playable terrain.
+                            </MudAlert>
                         </MudItem>
 
                         @* Hydraulic Erosion *@

--- a/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Pages/GenerateTerrain.razor.cs
@@ -2056,6 +2056,11 @@ public partial class GenerateTerrain : IDisposable
             if (result.UpdateTerrainBlock.HasValue)
                 _updateTerrainBlock = result.UpdateTerrainBlock.Value;
 
+            if (result.EnableTerrainBackdrop.HasValue)
+                _state.EnableTerrainBackdrop = result.EnableTerrainBackdrop.Value;
+            if (result.TerrainBackdropDistanceMeters.HasValue)
+                _state.TerrainBackdropDistanceMeters = result.TerrainBackdropDistanceMeters.Value;
+
             if (result.EnableCrossMaterialHarmonization.HasValue)
                 _enableCrossMaterialHarmonization = result.EnableCrossMaterialHarmonization.Value;
 

--- a/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainGenerationOrchestrator.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/Services/TerrainGenerationOrchestrator.cs
@@ -13,6 +13,7 @@ using BeamNgTerrainPoc.Terrain.Models.DecalRoad;
 using BeamNgTerrainPoc.Terrain.Models.RoadGeometry;
 using BeamNgTerrainPoc.Terrain.Osm.Models;
 using BeamNgTerrainPoc.Terrain.Building;
+using BeamNgTerrainPoc.Terrain.Export;
 using BeamNgTerrainPoc.Terrain.Osm.Processing;
 using BeamNgTerrainPoc.Terrain.Osm.Services;
 using BeamNG_LevelCleanUp.Utils;
@@ -269,6 +270,41 @@ public class TerrainGenerationOrchestrator
             else
                 PubSubChannel.SendMessage(PubSubMessageType.Warning,
                     "Could not update TerrainBlock - check warnings");
+
+            if (state.EnableTerrainBackdrop)
+            {
+                taskStopwatch.Restart();
+                if (terrainParameters?.OutputHeightMap == null)
+                {
+                    PubSubChannel.SendMessage(PubSubMessageType.Warning,
+                        "Terrain backdrop was not generated because the finished heightmap was unavailable.");
+                }
+                else
+                {
+                    try
+                    {
+                        var distanceMeters = Math.Clamp(state.TerrainBackdropDistanceMeters, 250f, 100000f);
+                        state.TerrainBackdropDistanceMeters = distanceMeters;
+                        var backdrop = TerrainBackdropExporter.Export(
+                            terrainParameters.OutputHeightMap,
+                            state.WorkingDirectory,
+                            state.LevelName,
+                            state.TerrainSize,
+                            state.MetersPerPixel,
+                            state.TerrainBaseHeight,
+                            distanceMeters);
+                        PubSubChannel.SendMessage(PubSubMessageType.Info,
+                            $"Generated {distanceMeters / 1000f:F2} km visual terrain backdrop " +
+                            $"({backdrop.VertexCount:N0} vertices, no collision).");
+                        Console.WriteLine($"[Perf] TerrainBackdropExporter: {taskStopwatch.ElapsedMilliseconds}ms");
+                    }
+                    catch (Exception ex)
+                    {
+                        PubSubChannel.SendMessage(PubSubMessageType.Warning,
+                            $"Terrain backdrop generation failed; playable terrain is unchanged: {ex.Message}");
+                    }
+                }
+            }
 
             // Handle spawn points
             taskStopwatch.Restart();

--- a/BeamNG_LevelCleanUp/BlazorUI/State/TerrainGenerationState.cs
+++ b/BeamNG_LevelCleanUp/BlazorUI/State/TerrainGenerationState.cs
@@ -33,6 +33,8 @@ public class TerrainGenerationState
     public float MetersPerPixel { get; set; } = 1.0f;
     public float TerrainBaseHeight { get; set; }
     public bool UpdateTerrainBlock { get; set; } = true;
+    public bool EnableTerrainBackdrop { get; set; }
+    public float TerrainBackdropDistanceMeters { get; set; } = 5000f;
     public bool EnableCrossMaterialHarmonization { get; set; } = true;
     public HydraulicErosionSettings HydraulicErosion { get; set; } = new();
 
@@ -389,6 +391,8 @@ public class TerrainGenerationState
         TerrainName = "theTerrain";
         TerrainBaseHeight = 0.0f;
         UpdateTerrainBlock = true;
+        EnableTerrainBackdrop = false;
+        TerrainBackdropDistanceMeters = 5000f;
         EnableCrossMaterialHarmonization = true;
         HydraulicErosion = new HydraulicErosionSettings();
         FlipMaterialProcessingOrder = false;

--- a/BeamNG_LevelCleanUp/LogicBasecolorManager/BaseColorModeApplier.cs
+++ b/BeamNG_LevelCleanUp/LogicBasecolorManager/BaseColorModeApplier.cs
@@ -4,6 +4,7 @@ using BeamNG_LevelCleanUp.LogicCopyAssets;
 using BeamNG_LevelCleanUp.Objects;
 using BeamNG_LevelCleanUp.Objects.MtSettings;
 using BeamNG_LevelCleanUp.Utils;
+using BeamNgTerrainPoc.Terrain.Export;
 using Grille.BeamNG.IO.Binary;
 
 namespace BeamNG_LevelCleanUp.LogicBasecolorManager;
@@ -28,7 +29,21 @@ public class BaseColorModeApplier
     {
         var terrainFolder = Path.GetDirectoryName(materialsJsonPath) ?? Path.Join(levelPath, "art", "terrains");
         var terrainSize = checked((int)terrain.Size);
-        var maps = _mapBuilder.BuildMaps(terrain, materials, terrainFolder, generateHeight, normalStrength, aoRadius, aoIntensity, overlayOptions, borderBlendOptions);
+        var backdropDirectory = Path.Combine(levelPath, "art", "shapes", TerrainBackdropExporter.GroupName);
+        var backdropTexturePath = Directory.Exists(backdropDirectory)
+            ? Path.Combine(backdropDirectory, TerrainBackdropExporter.BaseColorFileName)
+            : null;
+        var maps = _mapBuilder.BuildMaps(
+            terrain,
+            materials,
+            terrainFolder,
+            generateHeight,
+            normalStrength,
+            aoRadius,
+            aoIntensity,
+            overlayOptions,
+            borderBlendOptions,
+            backdropTexturePath);
         var jsonNode = JsonUtils.GetValidJsonNodeFromFilePath(materialsJsonPath);
 
         foreach (var property in jsonNode.AsObject().ToList())
@@ -46,6 +61,10 @@ public class BaseColorModeApplier
         File.WriteAllText(materialsJsonPath, jsonNode.ToJsonString(BeamJsonOptions.GetJsonSerializerOptions()));
         new PbrUpgradeHandler(materialsJsonPath, levelName, levelPath).EnsureTerrainMaterialTextureSetSize(terrainSize);
         DeletePaintModePlaceholders(terrainFolder);
+
+        if (backdropTexturePath != null && File.Exists(backdropTexturePath))
+            PubSubChannel.SendMessage(PubSubMessageType.Info,
+                $"Updated the visual terrain backdrop with a {TerrainBackdropExporter.MaximumTextureSize}px BaseColor texture.");
 
         settings.CurrentMode = BasecolorMode.BaseColorMode;
         settings.BasecolorModeSettings.Materials = materials.Select(MtTerrainMaterialSetting.FromCopyAsset).ToList();

--- a/BeamNG_LevelCleanUp/LogicBasecolorManager/TerrainPbrMapBuilder.cs
+++ b/BeamNG_LevelCleanUp/LogicBasecolorManager/TerrainPbrMapBuilder.cs
@@ -1,5 +1,6 @@
 using BeamNG_LevelCleanUp.Communication;
 using BeamNG_LevelCleanUp.Objects;
+using BeamNgTerrainPoc.Terrain.Export;
 using Grille.BeamNG.IO.Binary;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -22,7 +23,8 @@ public class TerrainPbrMapBuilder
         int aoRadius,
         double aoIntensity,
         BasecolorOverlayOptions? overlayOptions = null,
-        MaterialBorderBlendOptions? borderBlendOptions = null)
+        MaterialBorderBlendOptions? borderBlendOptions = null,
+        string? backdropTexturePath = null)
     {
         Directory.CreateDirectory(terrainFolder);
 
@@ -34,7 +36,14 @@ public class TerrainPbrMapBuilder
         var roughnessPath = Path.Join(terrainFolder, "MT_basecolor_r.png");
         var heightPath = Path.Join(terrainFolder, "MT_basecolor_h.png");
 
-        WriteMergedBaseColor(terrain, materialLookup, baseColorPath, size, overlayOptions, borderBlendOptions);
+        WriteMergedBaseColor(
+            terrain,
+            materialLookup,
+            baseColorPath,
+            size,
+            overlayOptions,
+            borderBlendOptions,
+            backdropTexturePath);
         WriteNormal(terrain, normalPath, size, normalStrength);
         WriteAo(terrain, aoPath, size, Math.Max(1, aoRadius), aoIntensity);
         WriteRoughness(terrain, materialLookup, roughnessPath, size, overlayOptions, borderBlendOptions);
@@ -112,7 +121,8 @@ public class TerrainPbrMapBuilder
         string path,
         int size,
         BasecolorOverlayOptions? overlayOptions,
-        MaterialBorderBlendOptions? borderBlendOptions)
+        MaterialBorderBlendOptions? borderBlendOptions,
+        string? backdropTexturePath)
     {
         using var overlay = LoadOverlayImage(overlayOptions, size);
         using var maskSet = LoadMaskSet(overlayOptions, size);
@@ -131,6 +141,18 @@ public class TerrainPbrMapBuilder
         ApplyMaterialBorderBlend(image, 1, borderBlendOptions);
 
         OverwritePng(image, path);
+        if (!string.IsNullOrWhiteSpace(backdropTexturePath))
+        {
+            using var backdrop = image.Clone(context => context.Resize(new ResizeOptions
+            {
+                Mode = ResizeMode.Max,
+                Size = new SixLabors.ImageSharp.Size(
+                    TerrainBackdropExporter.MaximumTextureSize,
+                    TerrainBackdropExporter.MaximumTextureSize),
+                Sampler = KnownResamplers.Lanczos3
+            }));
+            OverwritePng(backdrop, backdropTexturePath);
+        }
     }
 
     private static void WriteRoughness(

--- a/BeamNgTerrainPoc.Tests/Export/TerrainBackdropExporterTests.cs
+++ b/BeamNgTerrainPoc.Tests/Export/TerrainBackdropExporterTests.cs
@@ -77,6 +77,24 @@ public class TerrainBackdropExporterTests
         }
     }
 
+    [Theory]
+    [InlineData(0f, 0f, 0.5f, 0.5f)]
+    [InlineData(0f, 100f, 0.5f, 0f)]
+    [InlineData(0f, 200f, 0.5f, 0f)]
+    [InlineData(200f, 0f, 1f, 0.5f)]
+    [InlineData(-200f, -200f, 0f, 1f)]
+    public void BackdropUv_PreservesTerrainSeamAndClampsOutsideIt(
+        float worldX,
+        float worldY,
+        float expectedU,
+        float expectedV)
+    {
+        var uv = TerrainBackdropExporter.CalculateClampedTextureCoordinate(worldX, worldY, 100f);
+
+        Assert.Equal(expectedU, uv.X, 5);
+        Assert.Equal(expectedV, uv.Y, 5);
+    }
+
     private static string CreateLevelDirectory()
     {
         var levelPath = Path.Combine(Path.GetTempPath(), "terrain-backdrop-tests", Guid.NewGuid().ToString("N"));

--- a/BeamNgTerrainPoc.Tests/Export/TerrainBackdropExporterTests.cs
+++ b/BeamNgTerrainPoc.Tests/Export/TerrainBackdropExporterTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using BeamNgTerrainPoc.Terrain.Export;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace BeamNgTerrainPoc.Tests.Export;
+
+public class TerrainBackdropExporterTests
+{
+    [Fact]
+    public void Export_WritesSeparateNonCollidingSceneAndIsIdempotent()
+    {
+        var levelPath = CreateLevelDirectory();
+        try
+        {
+            var heightMap = new float[8, 8];
+            for (var y = 0; y < 8; y++)
+            for (var x = 0; x < 8; x++)
+                heightMap[y, x] = x + y * 2;
+
+            var first = TerrainBackdropExporter.Export(
+                heightMap, levelPath, "backdrop_test", 8, 1f, 100f, 1000f);
+            var second = TerrainBackdropExporter.Export(
+                heightMap, levelPath, "backdrop_test", 8, 1f, 100f, 2000f);
+
+            Assert.True(File.Exists(first.DaePath));
+            Assert.True(File.Exists(first.MaterialPath));
+            Assert.True(File.Exists(first.TexturePath));
+            Assert.True(second.VertexCount > first.VertexCount);
+            Assert.True(second.TriangleCount > first.TriangleCount);
+            Assert.Contains(TerrainBackdropExporter.MaterialName, File.ReadAllText(first.DaePath));
+
+            var parentItemsPath = Path.Combine(levelPath, "main", "MissionGroup", "items.level.json");
+            var groupEntries = File.ReadLines(parentItemsPath)
+                .Count(line => HasSceneIdentity(line, "SimGroup", TerrainBackdropExporter.GroupName));
+            Assert.Equal(1, groupEntries);
+
+            var backdropItemsPath = Path.Combine(
+                levelPath, "main", "MissionGroup", TerrainBackdropExporter.GroupName, "items.level.json");
+            var sceneLine = Assert.Single(File.ReadAllLines(backdropItemsPath));
+            using var scene = JsonDocument.Parse(sceneLine);
+            Assert.Equal("TSStatic", scene.RootElement.GetProperty("class").GetString());
+            Assert.Equal("None", scene.RootElement.GetProperty("collisionType").GetString());
+            Assert.DoesNotContain("TerrainBlock", sceneLine);
+        }
+        finally
+        {
+            Directory.Delete(levelPath, true);
+        }
+    }
+
+    [Fact]
+    public void RefreshTexture_DownsamplesFinalBaseColorTo2048Pixels()
+    {
+        var levelPath = CreateLevelDirectory();
+        try
+        {
+            var heightMap = new float[4, 4];
+            TerrainBackdropExporter.Export(heightMap, levelPath, "texture_test", 4, 1f, 0f, 500f);
+
+            var terrainDirectory = Path.Combine(levelPath, "art", "terrains");
+            Directory.CreateDirectory(terrainDirectory);
+            using (var source = new Image<Rgba32>(4096, 2048, new Rgba32(50, 100, 150, 255)))
+                source.SaveAsPng(Path.Combine(terrainDirectory, "MT_basecolor.png"));
+
+            Assert.True(TerrainBackdropExporter.RefreshTexture(levelPath));
+            var texturePath = Path.Combine(
+                levelPath, "art", "shapes", TerrainBackdropExporter.GroupName,
+                TerrainBackdropExporter.BaseColorFileName);
+            using var result = Image.Load<Rgba32>(texturePath);
+            Assert.Equal(2048, result.Width);
+            Assert.Equal(1024, result.Height);
+        }
+        finally
+        {
+            Directory.Delete(levelPath, true);
+        }
+    }
+
+    private static string CreateLevelDirectory()
+    {
+        var levelPath = Path.Combine(Path.GetTempPath(), "terrain-backdrop-tests", Guid.NewGuid().ToString("N"));
+        var missionGroupDirectory = Path.Combine(levelPath, "main", "MissionGroup");
+        Directory.CreateDirectory(missionGroupDirectory);
+        File.WriteAllText(
+            Path.Combine(missionGroupDirectory, "items.level.json"),
+            JsonSerializer.Serialize(new { name = "MissionGroup", @class = "SimGroup" }) + Environment.NewLine);
+        return levelPath;
+    }
+
+    private static bool HasSceneIdentity(string line, string className, string name)
+    {
+        using var document = JsonDocument.Parse(line);
+        return document.RootElement.GetProperty("class").GetString() == className &&
+               document.RootElement.GetProperty("name").GetString() == name;
+    }
+}

--- a/BeamNgTerrainPoc/Terrain/Export/TerrainBackdropExporter.cs
+++ b/BeamNgTerrainPoc/Terrain/Export/TerrainBackdropExporter.cs
@@ -96,9 +96,11 @@ public static class TerrainBackdropExporter
                         worldX,
                         worldY,
                         terrainBaseHeight + sampledHeight - SeamOffsetMeters);
-                    var u = (worldX + outerHalfExtent) / outerWorldSize;
-                    var v = 1f - (worldY + outerHalfExtent) / outerWorldSize;
-                    mesh.Vertices.Add(new Vertex(position, Vector3.UnitZ, new Vector2(u, v)));
+                    var textureCoordinate = CalculateClampedTextureCoordinate(
+                        worldX,
+                        worldY,
+                        innerHalfExtent);
+                    mesh.Vertices.Add(new Vertex(position, Vector3.UnitZ, textureCoordinate));
                 }
             }
 
@@ -192,6 +194,22 @@ public static class TerrainBackdropExporter
         var bottom = heightMap[y0, x0] + (heightMap[y0, x1] - heightMap[y0, x0]) * tx;
         var top = heightMap[y1, x0] + (heightMap[y1, x1] - heightMap[y1, x0]) * tx;
         return bottom + (top - bottom) * ty;
+    }
+
+    internal static Vector2 CalculateClampedTextureCoordinate(
+        float worldX,
+        float worldY,
+        float innerHalfExtent)
+    {
+        if (innerHalfExtent <= 0 || !float.IsFinite(innerHalfExtent))
+            throw new ArgumentOutOfRangeException(nameof(innerHalfExtent));
+
+        // The backdrop uses a lower-resolution copy of the playable BaseColor.
+        // Keep the texture aligned at the TerrainBlock seam, then extend its edge
+        // pixels outward instead of remapping the whole image over the larger ring.
+        var u = Math.Clamp((worldX + innerHalfExtent) / (innerHalfExtent * 2f), 0f, 1f);
+        var v = 1f - Math.Clamp((worldY + innerHalfExtent) / (innerHalfExtent * 2f), 0f, 1f);
+        return new Vector2(u, v);
     }
 
     private static void ApplySmoothNormals(Mesh mesh)

--- a/BeamNgTerrainPoc/Terrain/Export/TerrainBackdropExporter.cs
+++ b/BeamNgTerrainPoc/Terrain/Export/TerrainBackdropExporter.cs
@@ -1,0 +1,326 @@
+using System.Numerics;
+using System.Text.Json;
+using BeamNG.Procedural3D.Core;
+using BeamNG.Procedural3D.Exporters;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace BeamNgTerrainPoc.Terrain.Export;
+
+/// <summary>
+///     Exports a low-detail, non-colliding visual terrain ring around the playable TerrainBlock.
+///     The ring extends the finished terrain's edge heights outward and uses a downsampled copy
+///     of the BaseColor Manager output. It does not enlarge or repaint the editable TerrainBlock.
+/// </summary>
+public static class TerrainBackdropExporter
+{
+    public const string GroupName = "MT_terrain_backdrop";
+    public const string MaterialName = "mt_terrain_backdrop";
+    public const string BaseColorFileName = "backdrop_basecolor.png";
+    public const int MaximumTextureSize = 2048;
+
+    private const string ShapeFileName = "terrain_backdrop.dae";
+    private const float MinimumMeshStepMeters = 64f;
+    private const int MaximumSegmentsAcross = 256;
+    private const float SeamOffsetMeters = 0.05f;
+
+    public static TerrainBackdropExportResult Export(
+        float[,] heightMap,
+        string levelPath,
+        string levelName,
+        int terrainSize,
+        float metersPerPixel,
+        float terrainBaseHeight,
+        float distanceMeters)
+    {
+        ArgumentNullException.ThrowIfNull(heightMap);
+        ArgumentException.ThrowIfNullOrWhiteSpace(levelPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(levelName);
+
+        if (terrainSize < 2 || heightMap.GetLength(0) < 2 || heightMap.GetLength(1) < 2)
+            throw new ArgumentException("A terrain backdrop requires at least a 2 x 2 heightmap.", nameof(heightMap));
+        if (metersPerPixel <= 0 || !float.IsFinite(metersPerPixel))
+            throw new ArgumentOutOfRangeException(nameof(metersPerPixel), "Meters per pixel must be greater than zero.");
+        if (distanceMeters <= 0 || !float.IsFinite(distanceMeters))
+            throw new ArgumentOutOfRangeException(nameof(distanceMeters), "Backdrop distance must be greater than zero.");
+
+        var terrainWorldSize = terrainSize * metersPerPixel;
+        var innerHalfExtent = terrainWorldSize / 2f;
+        var outerHalfExtent = innerHalfExtent + distanceMeters;
+        var outerWorldSize = outerHalfExtent * 2f;
+        var meshStep = Math.Max(MinimumMeshStepMeters, outerWorldSize / MaximumSegmentsAcross);
+
+        var meshes = new List<Mesh>
+        {
+            BuildStrip("backdrop_north", -outerHalfExtent, outerHalfExtent, innerHalfExtent, outerHalfExtent),
+            BuildStrip("backdrop_south", -outerHalfExtent, outerHalfExtent, -outerHalfExtent, -innerHalfExtent),
+            BuildStrip("backdrop_west", -outerHalfExtent, -innerHalfExtent, -innerHalfExtent, innerHalfExtent),
+            BuildStrip("backdrop_east", innerHalfExtent, outerHalfExtent, -innerHalfExtent, innerHalfExtent)
+        };
+
+        var shapesDirectory = Path.Combine(levelPath, "art", "shapes", GroupName);
+        Directory.CreateDirectory(shapesDirectory);
+        var daePath = Path.Combine(shapesDirectory, ShapeFileName);
+        new ColladaExporter().ExportZUp(meshes, daePath);
+
+        var materialPath = Path.Combine(shapesDirectory, "main.materials.json");
+        WriteMaterial(materialPath, levelName);
+        RefreshTexture(levelPath);
+        WriteSceneEntry(levelPath, levelName);
+
+        return new TerrainBackdropExportResult(
+            daePath,
+            materialPath,
+            Path.Combine(shapesDirectory, BaseColorFileName),
+            meshes.Sum(mesh => mesh.VertexCount),
+            meshes.Sum(mesh => mesh.TriangleCount),
+            distanceMeters,
+            meshStep);
+
+        Mesh BuildStrip(string name, float minX, float maxX, float minY, float maxY)
+        {
+            var segmentsX = Math.Max(1, (int)Math.Ceiling((maxX - minX) / meshStep));
+            var segmentsY = Math.Max(1, (int)Math.Ceiling((maxY - minY) / meshStep));
+            var mesh = new Mesh { Name = name, MaterialName = MaterialName };
+
+            for (var y = 0; y <= segmentsY; y++)
+            {
+                var worldY = minY + (maxY - minY) * y / segmentsY;
+                for (var x = 0; x <= segmentsX; x++)
+                {
+                    var worldX = minX + (maxX - minX) * x / segmentsX;
+                    var sampledHeight = SampleClampedTerrainHeight(heightMap, worldX, worldY, innerHalfExtent);
+                    var position = new Vector3(
+                        worldX,
+                        worldY,
+                        terrainBaseHeight + sampledHeight - SeamOffsetMeters);
+                    var u = (worldX + outerHalfExtent) / outerWorldSize;
+                    var v = 1f - (worldY + outerHalfExtent) / outerWorldSize;
+                    mesh.Vertices.Add(new Vertex(position, Vector3.UnitZ, new Vector2(u, v)));
+                }
+            }
+
+            var stride = segmentsX + 1;
+            for (var y = 0; y < segmentsY; y++)
+            for (var x = 0; x < segmentsX; x++)
+            {
+                var bottomLeft = y * stride + x;
+                var bottomRight = bottomLeft + 1;
+                var topLeft = bottomLeft + stride;
+                var topRight = topLeft + 1;
+                mesh.Triangles.Add(new Triangle(bottomLeft, bottomRight, topRight));
+                mesh.Triangles.Add(new Triangle(bottomLeft, topRight, topLeft));
+            }
+
+            ApplySmoothNormals(mesh);
+            return mesh;
+        }
+    }
+
+    /// <summary>
+    ///     Refreshes the backdrop's intentionally lower-resolution texture from MT_basecolor.png.
+    ///     If BaseColor Mode has not run yet, a neutral placeholder prevents a missing-texture error.
+    /// </summary>
+    public static bool RefreshTexture(string levelPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(levelPath);
+        var outputDirectory = Path.Combine(levelPath, "art", "shapes", GroupName);
+        if (!Directory.Exists(outputDirectory))
+            return false;
+
+        var outputPath = Path.Combine(outputDirectory, BaseColorFileName);
+        var baseColorPath = Path.Combine(levelPath, "art", "terrains", "MT_basecolor.png");
+        if (File.Exists(baseColorPath))
+        {
+            var imageInfo = Image.Identify(baseColorPath);
+            Size? targetSize = null;
+            if (imageInfo.Width > MaximumTextureSize || imageInfo.Height > MaximumTextureSize)
+            {
+                var scale = Math.Min(
+                    MaximumTextureSize / (double)imageInfo.Width,
+                    MaximumTextureSize / (double)imageInfo.Height);
+                targetSize = new Size(
+                    Math.Max(1, (int)Math.Round(imageInfo.Width * scale)),
+                    Math.Max(1, (int)Math.Round(imageInfo.Height * scale)));
+            }
+
+            var decoderOptions = new DecoderOptions { TargetSize = targetSize };
+            using var image = Image.Load<Rgba32>(decoderOptions, baseColorPath);
+            if (image.Width > MaximumTextureSize || image.Height > MaximumTextureSize)
+            {
+                image.Mutate(context => context.Resize(new ResizeOptions
+                {
+                    Mode = ResizeMode.Max,
+                    Size = new Size(MaximumTextureSize, MaximumTextureSize),
+                    Sampler = KnownResamplers.Lanczos3
+                }));
+            }
+
+            SaveReplacing(image, outputPath);
+            return true;
+        }
+
+        if (File.Exists(outputPath))
+            return false;
+
+        using var placeholder = new Image<Rgba32>(4, 4, new Rgba32(128, 128, 128, 255));
+        placeholder.SaveAsPng(outputPath);
+        return false;
+    }
+
+    private static float SampleClampedTerrainHeight(
+        float[,] heightMap,
+        float worldX,
+        float worldY,
+        float innerHalfExtent)
+    {
+        var width = heightMap.GetLength(1);
+        var height = heightMap.GetLength(0);
+        var clampedX = Math.Clamp(worldX, -innerHalfExtent, innerHalfExtent);
+        var clampedY = Math.Clamp(worldY, -innerHalfExtent, innerHalfExtent);
+        var pixelX = (clampedX + innerHalfExtent) / (innerHalfExtent * 2f) * (width - 1);
+        var pixelY = (clampedY + innerHalfExtent) / (innerHalfExtent * 2f) * (height - 1);
+
+        var x0 = Math.Clamp((int)Math.Floor(pixelX), 0, width - 1);
+        var y0 = Math.Clamp((int)Math.Floor(pixelY), 0, height - 1);
+        var x1 = Math.Min(width - 1, x0 + 1);
+        var y1 = Math.Min(height - 1, y0 + 1);
+        var tx = pixelX - x0;
+        var ty = pixelY - y0;
+        var bottom = heightMap[y0, x0] + (heightMap[y0, x1] - heightMap[y0, x0]) * tx;
+        var top = heightMap[y1, x0] + (heightMap[y1, x1] - heightMap[y1, x0]) * tx;
+        return bottom + (top - bottom) * ty;
+    }
+
+    private static void ApplySmoothNormals(Mesh mesh)
+    {
+        var normals = new Vector3[mesh.VertexCount];
+        foreach (var triangle in mesh.Triangles)
+        {
+            var a = mesh.Vertices[triangle.V0].Position;
+            var b = mesh.Vertices[triangle.V1].Position;
+            var c = mesh.Vertices[triangle.V2].Position;
+            var faceNormal = Vector3.Cross(b - a, c - a);
+            if (faceNormal.LengthSquared() <= float.Epsilon)
+                continue;
+            normals[triangle.V0] += faceNormal;
+            normals[triangle.V1] += faceNormal;
+            normals[triangle.V2] += faceNormal;
+        }
+
+        for (var index = 0; index < mesh.VertexCount; index++)
+        {
+            var normal = normals[index].LengthSquared() > float.Epsilon
+                ? Vector3.Normalize(normals[index])
+                : Vector3.UnitZ;
+            mesh.Vertices[index] = mesh.Vertices[index].WithNormal(normal);
+        }
+    }
+
+    private static void WriteMaterial(string materialPath, string levelName)
+    {
+        var material = new Dictionary<string, object?>
+        {
+            ["class"] = "Material",
+            ["name"] = MaterialName,
+            ["mapTo"] = MaterialName,
+            ["internalName"] = MaterialName,
+            ["persistentId"] = Guid.NewGuid().ToString(),
+            ["version"] = 1.5f,
+            ["doubleSided"] = false,
+            ["translucentBlendOp"] = "None",
+            ["Stages"] = new object[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["baseColorMap"] = $"/levels/{levelName}/art/shapes/{GroupName}/{BaseColorFileName}",
+                    ["baseColorFactor"] = new[] { 1f, 1f, 1f, 1f },
+                    ["roughnessFactor"] = 1f
+                },
+                new Dictionary<string, object>(),
+                new Dictionary<string, object>(),
+                new Dictionary<string, object>()
+            }
+        };
+
+        var root = new Dictionary<string, object?> { [MaterialName] = material };
+        File.WriteAllText(materialPath, JsonSerializer.Serialize(root, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static void WriteSceneEntry(string levelPath, string levelName)
+    {
+        var parentItemsPath = Path.Combine(levelPath, "main", "MissionGroup", "items.level.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(parentItemsPath)!);
+        var lines = File.Exists(parentItemsPath)
+            ? File.ReadAllLines(parentItemsPath).ToList()
+            : new List<string>();
+
+        var hasGroup = lines.Any(line => IsNamedSceneObject(line, "SimGroup", GroupName));
+        if (!hasGroup)
+        {
+            lines.Add(JsonSerializer.Serialize(new Dictionary<string, object>
+            {
+                ["name"] = GroupName,
+                ["class"] = "SimGroup",
+                ["persistentId"] = Guid.NewGuid().ToString(),
+                ["__parent"] = "MissionGroup"
+            }));
+            File.WriteAllLines(parentItemsPath, lines);
+        }
+
+        var sceneDirectory = Path.Combine(levelPath, "main", "MissionGroup", GroupName);
+        Directory.CreateDirectory(sceneDirectory);
+        var sceneItem = new Dictionary<string, object>
+        {
+            ["name"] = GroupName,
+            ["class"] = "TSStatic",
+            ["persistentId"] = Guid.NewGuid().ToString(),
+            ["__parent"] = GroupName,
+            ["position"] = new[] { 0f, 0f, 0f },
+            ["rotationMatrix"] = new[] { 1f, 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f },
+            ["shapeName"] = $"/levels/{levelName}/art/shapes/{GroupName}/{ShapeFileName}",
+            ["collisionType"] = "None",
+            ["decalType"] = "None",
+            ["useInstanceRenderData"] = true
+        };
+        File.WriteAllText(
+            Path.Combine(sceneDirectory, "items.level.json"),
+            JsonSerializer.Serialize(sceneItem) + Environment.NewLine);
+    }
+
+    private static bool IsNamedSceneObject(string line, string className, string name)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+            return false;
+        try
+        {
+            using var document = JsonDocument.Parse(line);
+            return document.RootElement.TryGetProperty("class", out var classElement) &&
+                   classElement.GetString() == className &&
+                   document.RootElement.TryGetProperty("name", out var nameElement) &&
+                   nameElement.GetString() == name;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static void SaveReplacing(Image<Rgba32> image, string outputPath)
+    {
+        if (File.Exists(outputPath))
+            File.Delete(outputPath);
+        image.SaveAsPng(outputPath);
+    }
+}
+
+public sealed record TerrainBackdropExportResult(
+    string DaePath,
+    string MaterialPath,
+    string TexturePath,
+    int VertexCount,
+    int TriangleCount,
+    float DistanceMeters,
+    float MeshStepMeters);


### PR DESCRIPTION
## Summary
- add an optional backdrop-distance setting to terrain generation and terrain presets
- generate a low-detail, non-colliding visual mesh ring outside the playable TerrainBlock
- continue the finished terrain edge heights into the backdrop to avoid a visible seam
- apply a downsampled 2048 px copy of MT_basecolor.png as the backdrop material without painting or replacing playable terrain
- clamp the playable BaseColor edge pixels outward so the low-resolution backdrop stays aligned at the TerrainBlock seam
- keep backdrop assets in a dedicated MT_terrain_backdrop group so cleanup/basecolor operations can leave them separate

## Validation
- 342 tests passed, including backdrop export, idempotency, texture downsampling, and UV seam coverage
- application build completed with 0 errors